### PR TITLE
Use web site update page to determine download

### DIFF
--- a/NEC/SpectraViewII.download.recipe
+++ b/NEC/SpectraViewII.download.recipe
@@ -19,9 +19,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>URL=(http.*dmg)</string>
+				<string>http.*dmg</string>
 				<key>url</key>
-				<string>http://update.necdisplay.com/spectraview/updates.txt</string>
+				<string>http://www.necdisplay.com/support-and-services/spectra-view-II/Downloads</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
update.necdisplay.com/spectraview/updates.txt did not get updated on the last update, so the recipe is not fetching the latest version. Pointing to the current download web page correctly fetches the latest version, even though it is more fragile. Also, simplified re_pattern for the new source.