### PR TITLE
fix orphaned less_than sign

### DIFF
--- a/EFI/GenericFieryFD50.pkg.recipe
+++ b/EFI/GenericFieryFD50.pkg.recipe
@@ -18,9 +18,9 @@ Set the Input in the override to the following suggested items:
 - PACKAGE_VERSION of 1.$version, where $version is the digits after "FD" in the downloaded driver (e.g. 1.51)
 
 Run the recipe with the "-p" option pointing to the downloaded driver dmg:
-autopkg run Ricoh_E41_v1_0R_FD51_v1Cert.pkg -p /path/to/Ricoh_E41_v1_0R_FD51_v1Cert.dmg<
+autopkg run Ricoh_E41_v1_0R_FD51_v1Cert.pkg -p /path/to/Ricoh_E41_v1_0R_FD51_v1Cert.dmg
 
-Also note that the way that EFI's package postinstall is written causes it to behave differently when COMMAND_LINE_INSTALL is set.  When testing the output package, make sure to use "installer" rather than double-clicking the package.  From a different point of view, when the package output from this recipe installed via the GUI (i.e. Installer.app) it will NOT have the desired result of skipping the Fiery Driver Updater installation and running non-interactively./string>
+Also note that the way that EFI's package postinstall is written causes it to behave differently when COMMAND_LINE_INSTALL is set.  When testing the output package, make sure to use "installer" rather than double-clicking the package.  From a different point of view, when the package output from this recipe installed via the GUI (i.e. Installer.app) it will NOT have the desired result of skipping the Fiery Driver Updater installation and running non-interactively.</string>
 	<key>Identifier</key>
 	<string>com.github.foigus.pkg.GenericFieryFD50</string>
 	<key>Input</key>


### PR DESCRIPTION
this was causing an error over and over on my system:

```
WARNING: plist error for /Users/nperkins/autopkg/repos/com.github.autopkg.foigus-recipes/EFI/GenericFieryFD50.pkg.recipe: Error Domain=NSCocoaErrorDomain Code=3840 "Encountered unexpected character 
 on line 21 while looking for close tag" UserInfo={NSDebugDescription=Encountered unexpected character 
 on line 21 while looking for close tag, kCFPropertyListOldStyleParsingError=Error Domain=NSCocoaErrorDomain Code=3840 "Malformed data byte group at line 1; invalid hex" UserInfo={NSDebugDescription=Malformed data byte group at line 1; invalid hex}}
```