### PR TITLE
Update parent recipe identifier

### DIFF
--- a/Microsoft/MicrosoftRemoteDesktop.munki.recipe
+++ b/Microsoft/MicrosoftRemoteDesktop.munki.recipe
@@ -41,7 +41,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.rtrouton.download.microsoftremotedesktop</string>
+	<string>corp.sap.maccoe.download.microsoftremotedesktop</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Upstream changed from com.github.rtrouton.download.microsoftremotedesktop to corp.sap.maccoe.download.microsoftremotedesktop