### PR TITLE
Added pkg recipe for Screenflick.

### DIFF
--- a/Araelium/Screenflick.pkg.recipe
+++ b/Araelium/Screenflick.pkg.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the current release version of Screenflick and builds a package. Added by Sean Hansell</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.pkg.Screenflick</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>Screenflick</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.foigus.download.Screenflick</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>app_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This is for my use, as I deploy this in a Jamf environment and I can't use the download recipe you've written without a pkg recipe. I can host this in my own repo or leave it with you where the corresponding download recipe lives. It's entirely up to you.