### PR TITLE
Added CHECK_FILESIZE_ONLY to UrlDownloader

### DIFF
--- a/Meteo/Meteorologist.download.recipe
+++ b/Meteo/Meteorologist.download.recipe
@@ -38,6 +38,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>CHECK_FILESIZE_ONLY</key>
+                                <true/>
 				<key>filename</key>
 				<string>Meteorologist.dmg</string>
 				<key>url</key>


### PR DESCRIPTION
Added CHECK_FILESIZE_ONLY to UrlDownloader as AutoPkg always notify for a new version and the ETag header is even different - mirrors?