### PR TITLE
Product Name has changed to "Google Ads Editor"

### DIFF
--- a/Google/GoogleAdsEditor.download.recipe
+++ b/Google/GoogleAdsEditor.download.recipe
@@ -3,15 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Google AdWords Editor disk image.</string>
+	<string>Downloads latest Google Ads Editor disk image.</string>
 	<key>Identifier</key>
-	<string>com.github.foigus.download.googleadwordseditor</string>
+	<string>com.github.foigus.download.googleadseditor</string>
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
 		<string>https://dl.google.com/adwords_editor/Google_AdWords_Editor.dmg</string>
 		<key>NAME</key>
-		<string>GoogleAdWordsEditor</string>
+		<string>GoogleAdsEditor</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -60,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Google AdWords Editor.app</string>
+				<string>%pathname%/Google Ads Editor.app</string>
 				<key>requirement</key>
 				<string>identifier "com.google.googleadwordseditorlauncher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
 			</dict>

--- a/Google/GoogleAdsEditor.munki.recipe
+++ b/Google/GoogleAdsEditor.munki.recipe
@@ -3,29 +3,29 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Google AdWords Editor disk image, builds an installation package, and imports it into Munki.
+	<string>Downloads latest Google Ads Editor disk image, builds an installation package, and imports it into Munki.
 
 NOTE: This package carries the Google Keystone updater.  To get rid of the Keystone updater, set the following postuninstall_script in your override
 
 ###
 #!/bin/bash
 
-rm "/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/Keystone.tbz" \
-"/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/ksinstall"
+rm "/Applications/Google Ads Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/Keystone.tbz" \
+"/Applications/Google Ads Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/ksinstall"
 ###</string>
 	<key>Identifier</key>
-	<string>com.github.foigus.munki.googleadwordseditor</string>
+	<string>com.github.foigus.munki.googleadseditor</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/google</string>
 		<key>NAME</key>
-		<string>GoogleAdWordsEditor</string>
+		<string>GoogleAdsEditor</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>
 			<array>
-				<string>Google AdWords Editor</string>
+				<string>Google Ads Editor</string>
 			</array>
 			<key>catalogs</key>
 			<array>
@@ -38,7 +38,7 @@ rm "/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistra
 			<key>developer</key>
 			<string>Google</string>
 			<key>display_name</key>
-			<string>Google AdWords Editor</string>
+			<string>Google Ads Editor</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -50,7 +50,7 @@ rm "/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistra
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.foigus.pkg.googleadwordseditor</string>
+	<string>com.github.foigus.pkg.googleadseditor</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Google/GoogleAdsEditor.pkg.recipe
+++ b/Google/GoogleAdsEditor.pkg.recipe
@@ -3,29 +3,29 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Google AdWords Editor disk image and builds an installation package.
+	<string>Downloads latest Google Ads Editor disk image and builds an installation package.
 
 NOTE: This package carries the Google Keystone updater.  To get rid of the Keystone updater, run the following script in your software management system following installation:
 
 ###
 #!/bin/bash
 
-rm "/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/Keystone.tbz" \
-"/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/ksinstall"
+rm "/Applications/Google Ads Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/Keystone.tbz" \
+"/Applications/Google Ads Editor.app/Contents/Frameworks/KeystoneRegistration.framework/Versions/A/Resources/ksinstall"
 ###</string>
 	<key>Identifier</key>
-	<string>com.github.foigus.pkg.googleadwordseditor</string>
+	<string>com.github.foigus.pkg.googleadseditor</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>GoogleAdWordsEditor</string>
+		<string>GoogleAdsEditor</string>
 		<key>PKGID</key>
 		<string>com.google.googleadwordseditor</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.foigus.download.googleadwordseditor</string>
+	<string>com.github.foigus.download.googleadseditor</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -46,9 +46,9 @@ rm "/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistra
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkg_root/Applications/Google AdWords Editor.app</string>
+				<string>%RECIPE_CACHE_DIR%/pkg_root/Applications/Google Ads Editor.app</string>
 				<key>source_path</key>
-				<string>%pathname%/Google AdWords Editor.app</string>
+				<string>%pathname%/Google Ads Editor.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -74,7 +74,7 @@ rm "/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistra
 							<key>mode</key>
 							<string>0644</string>
 							<key>path</key>
-							<string>Applications/Google AdWords Editor.app/Contents/Info.plist</string>
+							<string>Applications/Google Ads Editor.app/Contents/Info.plist</string>
 							<key>user</key>
 							<string>root</string>
 						</dict>
@@ -84,7 +84,7 @@ rm "/Applications/Google AdWords Editor.app/Contents/Frameworks/KeystoneRegistra
 							<key>mode</key>
 							<string>0644</string>
 							<key>path</key>
-							<string>Applications/Google AdWords Editor.app/Contents/Versions/%version%/Google AdWords Editor.app/Contents/Info.plist</string>
+							<string>Applications/Google Ads Editor.app/Contents/Versions/%version%/Google Ads Editor.app/Contents/Info.plist</string>
 							<key>user</key>
 							<string>root</string>
 						</dict>


### PR DESCRIPTION
The app is now named "Google Ads Editor.app".
Download URL, Code Signature and Identifier remain unchanged.