### PR TITLE
Add support for handling patch releases of Android Studio

### DIFF
--- a/Google/AndroidStudio.munki.recipe
+++ b/Google/AndroidStudio.munki.recipe
@@ -16,6 +16,10 @@ autopkg repo-add novaksam-recipes</string>
 		<string>apps/android</string>
 		<key>NAME</key>
 		<string>AndroidStudio</string>
+		<key>VERSION_SEARCH_PATTERN</key>
+		<string>https\://dl\.google\.com/dl/android/studio/install/([0-9.]+)/android-studio-ide.+\.dmg</string>
+		<key>VERSION_SEARCH_URL</key>
+		<string>https://developer.android.com/sdk/index.html</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -49,10 +53,29 @@ autopkg repo-add novaksam-recipes</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>re_pattern</key>
+				<string>%VERSION_SEARCH_PATTERN%</string>
+				<key>url</key>
+				<string>%VERSION_SEARCH_URL%</string>
+				<key>result_output_var_name</key>
+				<string>found_version_number</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--pkgvers=%found_version_number%</string>
+				</array>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
I noticed that newer patch releases (e.g. 3.3.2 with .2 being the patch release) of Android Studio were not getting imported into my Munki repo if I had a previous version in the repo that matched the major + minor version of the download (e.g. 3.3.x).

After investigating, I discovered that Google does not include the patch version number in the `CFBundleShortVersionString`. This means all 3.3.x releases have a `CFBundleShortVersionString` of 3.3.

This PR adds support for handling patch releases by:

- Setting the `version` key of the pkginfo file to match the full version number (e.g. 3.3.2 instead of 3.3)
- Setting the `version_comparison_key` to `CFBundleVersion` instead of `CFBundleShortVersionString` as a workaround until if/when Google sets `CFBundleShortVersionString` to the full version number. This is needed since the MunkiImporter processor uses `CFBundleShortVersionString` by default to check if an item already exists in a Munki repo.