### PR TITLE
add pkg_ids_set_optional_true to Microsoft Remote Desktop

### DIFF
--- a/Microsoft/MicrosoftRemoteDesktop.munki.recipe
+++ b/Microsoft/MicrosoftRemoteDesktop.munki.recipe
@@ -12,6 +12,8 @@
 		<string>apps/microsoft</string>
 		<key>NAME</key>
 		<string>MicrosoftRemoteDesktop</string>
+		<key>pkg_ids_set_optional_true</key>
+		<array/>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>
@@ -54,6 +56,10 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Added a blank array so it wouldn't break any existing uses. Only issue would be if someone didn't have Sam's repo added.

```
$ autopkg run ./MicrosoftRemoteDesktop.munki.recipe
Processing ./MicrosoftRemoteDesktop.munki.recipe...
WARNING: ./MicrosoftRemoteDesktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

The following new items were imported into Munki:
    Name                    Version  Catalogs                                      Pkginfo Path                                         Pkg Repo Path                                        
    ----                    -------  --------                                      ------------                                         -------------                                        
    MicrosoftRemoteDesktop  10.2.13  development-microsoft-MicrosoftRemoteDesktop  apps/microsoft/MicrosoftRemoteDesktop-10.2.13.plist  apps/microsoft/Microsoft_Remote_Desktop-10.2.13.pkg  

The following new items were downloaded:
    Download Path                                                                                                              
    -------------                                                                                                              
    /Users/cwhits/Library/AutoPkg/Cache/com.github.foigus.munki.microsoftremotedesktop/downloads/Microsoft_Remote_Desktop.pkg  

```

thoughts?