### PR TITLE
Update GoogleAdsEditor.download.recipe

### DIFF
--- a/Google/GoogleAdsEditor.download.recipe
+++ b/Google/GoogleAdsEditor.download.recipe
@@ -62,7 +62,7 @@
 				<key>input_path</key>
 				<string>%pathname%/Google Ads Editor.app</string>
 				<key>requirement</key>
-				<string>identifier "com.google.googleadwordseditorlauncher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
+				<string>identifier "com.google.googleadseditorlauncher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Updated identifier for CodeSignatureVerifier.
```
$ codesign --display -r- --deep -v /Volumes/Google\ Ads\ Editor/Google\ Ads\ Editor.app/
Executable=/Volumes/Google Ads Editor/Google Ads Editor.app/Contents/MacOS/Google Ads Editor Launcher
Identifier=com.google.googleadseditorlauncher
Format=app bundle with Mach-O thin (x86_64)
CodeDirectory v=20500 size=558 flags=0x10000(???) hashes=10+3 location=embedded
Signature size=8961
Timestamp=Jul 22, 2019, 7:58:21 AM
Info.plist entries=12
TeamIdentifier=EQHXZ8M8AV
Sealed Resources version=2 rules=13 files=297
Nested=Frameworks/KeystoneRegistration.framework
Nested=Frameworks/QtCore.framework
designated => identifier "com.google.googleadseditorlauncher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV
```