### PR TITLE
Deprecate TB2 download recipe

### DIFF
--- a/Arris/TimbuktuPro.download.recipe
+++ b/Arris/TimbuktuPro.download.recipe
@@ -20,6 +20,10 @@ Not running CodeSignatureVerifier due to V1 code signature.</string>
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>

--- a/Arris/TimbuktuPro.download.recipe
+++ b/Arris/TimbuktuPro.download.recipe
@@ -16,7 +16,7 @@ Not running CodeSignatureVerifier due to V1 code signature.</string>
 		<string>TimbuktuPro</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.0</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This will produce a warning for people still running the recipe (or any child recipe).

Rest in peace!