### PR TITLE
Remove FEED_URL Input

### DIFF
--- a/BebopTechnology/BebopClient.download.recipe
+++ b/BebopTechnology/BebopClient.download.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.foigus.download.bebopclient</string>
 	<key>Input</key>
 	<dict>
-		<key>FEED_URL</key>
-		<string>https://bebop-clients-v3.s3.amazonaws.com/prod/latest-mac.yml</string>
 		<key>NAME</key>
 		<string>BebopClient</string>
 	</dict>


### PR DESCRIPTION
FEED_URL is an input but that variable isn’t referenced later. 
Also, the Input makes it appear in the override so if the parent recipe ever changes the yaml path, the override won’t get the change as the original value is still in the override recipe.  I suggest taking the FEED_URL out all together and just let the download recipe have that value hard coded like it is already.