### PR TITLE
Updated Tableaus developer cert company name

### DIFF
--- a/Tableau/TableauPublic.download.recipe
+++ b/Tableau/TableauPublic.download.recipe
@@ -39,7 +39,7 @@
 				<string>%pathname%/Tableau Public.pkg</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Tableau Software, Inc. (QJ4XPRK37C)</string>
+					<string>Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>

--- a/Tableau/TableauReader.download.recipe
+++ b/Tableau/TableauReader.download.recipe
@@ -37,7 +37,7 @@
 				<string>%pathname%/Tableau Reader.pkg</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Tableau Software, Inc. (QJ4XPRK37C)</string>
+					<string>Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
Tableau appears to have changed their corporate structure to an LLC. Their developer cert has changed as a result. This commit updates the expected authority names to reflect this.