### PR TITLE
Issues downloading from the built URL - possible fix

### DIFF
--- a/PhaseOne/CaptureOne.download.recipe
+++ b/PhaseOne/CaptureOne.download.recipe
@@ -35,7 +35,7 @@ Due to Phase One's decision to go with different versions for the software itsel
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>&lt;AvailableVersion&gt;(%ACTUAL_VERSION%[\.\d]*)\.[\d]*&lt;\/AvailableVersion&gt;</string>
+				<string>&lt;AvailableVersion&gt;(%ACTUAL_VERSION%[\.\d]*\.[\d]*)&lt;\/AvailableVersion&gt;</string>
 				<key>result_output_var_name</key>
 				<string>truncated_version</string>
 				<key>url</key>

--- a/PhaseOne/CaptureOne.download.recipe
+++ b/PhaseOne/CaptureOne.download.recipe
@@ -35,7 +35,7 @@ Due to Phase One's decision to go with different versions for the software itsel
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>&lt;AvailableVersion&gt;(%ACTUAL_VERSION%[\.\d]*\.[\d]*)&lt;\/AvailableVersion&gt;</string>
+				<string>&lt;AvailableVersion&gt;(%ACTUAL_VERSION%[\.\d]*)&lt;\/AvailableVersion&gt;</string>
 				<key>result_output_var_name</key>
 				<string>truncated_version</string>
 				<key>url</key>


### PR DESCRIPTION
Currently this recipe errors with the below:
`Error in local.munki.CaptureOne-dataJAR: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://downloads.phaseone.com/374dd05f-e8c7-499d-a703-9a7dca20d5b7/International/CaptureOne20.Mac.13.1.2.dmg', '--fail', '--output', '/Users/sadmin/Library/AutoPkg/Cache/local.munki.CaptureOne-dataJAR/downloads/tmpb0k2jo8h']' returned non-zero exit status 22.`

With this tweak they look to download the disk image fine