### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Blurb/Blurb.download.recipe
+++ b/Blurb/Blurb.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://software.blurb.com/indesign/Blurb_ID_PlugIn_Installer.pkg</string>
+		<string>https://software.blurb.com/indesign/Blurb_ID_PlugIn_Installer.pkg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>

--- a/EIZO/ColorNavigator.download.recipe
+++ b/EIZO/ColorNavigator.download.recipe
@@ -25,7 +25,7 @@ As of this writing, the valid LANGUAGE_CODEs are "en" (English) and "ja" (Japane
 				<key>re_pattern</key>
 				<string>hreflang="%LANGUAGE_CODE%" href="(.*.dmg)</string>
 				<key>url</key>
-				<string>http://www.eizo.co.jp/update/ColorNavigator.xml</string>
+				<string>https://www.eizo.co.jp/update/ColorNavigator.xml</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/EIZO/ColorNavigator.pkg.recipe
+++ b/EIZO/ColorNavigator.pkg.recipe
@@ -25,7 +25,7 @@
 				<key>result_output_var_name</key>
 				<string>major_version</string>
 				<key>url</key>
-				<string>http://www.eizo.co.jp/update/ColorNavigator.xml</string>
+				<string>https://www.eizo.co.jp/update/ColorNavigator.xml</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/EIZO/ColorNavigatorNX.download.recipe
+++ b/EIZO/ColorNavigatorNX.download.recipe
@@ -25,7 +25,7 @@ As of this writing, the valid LANGUAGE_CODEs are "en" (English) and "ja" (Japane
 				<key>re_pattern</key>
 				<string>hreflang="%LANGUAGE_CODE%" href="(.*.dmg)</string>
 				<key>url</key>
-				<string>http://www.eizo.co.jp/update/ColorNavigatorNX.xml</string>
+				<string>https://www.eizo.co.jp/update/ColorNavigatorNX.xml</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/QuiteSoftware/QuiteImposing.download.recipe
+++ b/QuiteSoftware/QuiteImposing.download.recipe
@@ -31,7 +31,7 @@ Code signature verification isn't possible because the installer isn't signed.</
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://downloads.quite.com/imposing/download/qi%PLUS%%MAJOR_VERSION%_%LANGUAGE%.dmg</string>
+				<string>https://downloads.quite.com/imposing/download/qi%PLUS%%MAJOR_VERSION%_%LANGUAGE%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Telestream/Wirecast.download.recipe
+++ b/Telestream/Wirecast.download.recipe
@@ -23,7 +23,7 @@
 				<key>result_output_var_name</key>
 				<string>url_suffix</string>
 				<key>url</key>
-				<string>http://www.telestream.net/update-check/wirecast/upgrade.htm?premium=no</string>
+				<string>https://www.telestream.net/update-check/wirecast/upgrade.htm?premium=no</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/ZevrixSolutions/InPreflightPro.download.recipe
+++ b/ZevrixSolutions/InPreflightPro.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://zevrix.com/InPreflight.dmg</string>
+		<string>https://zevrix.com/InPreflight.dmg</string>
 		<key>NAME</key>
 		<string>InPreflightPro</string>
 	</dict>

--- a/ZevrixSolutions/OutputFactory.download.recipe
+++ b/ZevrixSolutions/OutputFactory.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://zevrix.com/OutputFactory.dmg</string>
+		<string>https://zevrix.com/OutputFactory.dmg</string>
 		<key>NAME</key>
 		<string>OutputFactory</string>
 	</dict>


### PR DESCRIPTION
Detected and changed HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure download success.