### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/BebopTechnology/BebopClient.download.recipe
+++ b/BebopTechnology/BebopClient.download.recipe
@@ -55,7 +55,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/BebopClient.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "bebop.id" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "97K63EKLMY"</string>
 			</dict>
 		</dict>

--- a/Google/GoogleChromeCanary.download.recipe
+++ b/Google/GoogleChromeCanary.download.recipe
@@ -41,7 +41,7 @@ CodeSignatureVerifier disabled as of 3/22/2016 (verified 7/11/2016) due to "reso
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/Google Chrome Canary.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>(identifier "com.google.Chrome" or identifier "com.google.Chrome.beta" or identifier "com.google.Chrome.dev" or identifier "com.google.Chrome.canary") and certificate leaf = H"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a"</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.