### PR TITLE
Change requirement for CodeSignatureVerifier in SpectraViewII.download

### DIFF
--- a/NEC/SpectraViewII.download.recipe
+++ b/NEC/SpectraViewII.download.recipe
@@ -47,7 +47,7 @@
 				<key>input_path</key>
 				<string>%pathname%/SpectraView II.app</string>
 				<key>requirement</key>
-				<string>identifier "com.necdisplay.SpectraViewII" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6GF762JEZP"</string>
+				<string>identifier "com.necdisplay.SpectraViewII" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "77XL9RA8Q5"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
The Sharp/NEC merger has changed the app signature as 1.1.42