### PR TITLE
Adjust parent recipes for sheagcraig-recipes repo deprecation

### DIFF
--- a/OpenEmu/OpenEmu.munki.recipe
+++ b/OpenEmu/OpenEmu.munki.recipe
@@ -35,7 +35,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.download.OpenEmu</string>
+	<string>com.github.homebysix.download.OpenEmu</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The sheagcraig-recipes repository is being deprecated (details here: https://github.com/autopkg/sheagcraig-recipes/issues/71). Many working and/or serviceable recipes have already been [copied](https://github.com/autopkg/homebysix-recipes/pull/414) to the homebysix-recipes repo. This PR changes the parent recipes in your repo to point to the homebysix-recipes version of any affected recipes.

In addition to updating trust info, users of the changed recipes will need to ensure the homebysix-recipes repo is added to their AutoPkg environment (`autopkg repo-add homebysix-recipes`).