### PR TITLE
Update AndroidStudio.munki.recipe

### DIFF
--- a/Google/AndroidStudio.munki.recipe
+++ b/Google/AndroidStudio.munki.recipe
@@ -2,80 +2,61 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads latest Android Studio disk image and imports into Munki.
+    <key>Description</key>
+    <string>Downloads latest Android Studio disk image and imports into Munki.
 
 This recipe is dependent on Sam Novak's Android Studio recipe.  To add his repo:
 
 autopkg repo-add novaksam-recipes</string>
-	<key>Identifier</key>
-	<string>com.github.foigus.munki.AndroidStudio</string>
-	<key>Input</key>
-	<dict>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/android</string>
-		<key>NAME</key>
-		<string>AndroidStudio</string>
-		<key>VERSION_SEARCH_PATTERN</key>
-		<string>https\://redirector\.gvt1\.com/edgedl/android/studio/install/([0-9.]+)/android-studio-ide.+\.dmg</string>
-		<key>VERSION_SEARCH_URL</key>
-		<string>https://developer.android.com/sdk/index.html</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>development-android-AndroidStudio</string>
-			</array>
-			<key>category</key>
-			<string>Development</string>
-			<key>description</key>
-			<string>Android Studio is the official IDE for Android application development, based on IntelliJ IDEA.</string>
-			<key>developer</key>
-			<string>Google</string>
-			<key>display_name</key>
-			<string>Android Studio</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.2.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.novaksam.download.AndroidStudio</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>%VERSION_SEARCH_PATTERN%</string>
-				<key>url</key>
-				<string>%VERSION_SEARCH_URL%</string>
-				<key>result_output_var_name</key>
-				<string>found_version_number</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%pathname%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>additional_makepkginfo_options</key>
-				<array>
-					<string>--pkgvers=%found_version_number%</string>
-				</array>
-				<key>version_comparison_key</key>
-				<string>CFBundleVersion</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
-	</array>
+    <key>Identifier</key>
+    <string>com.github.foigus.munki.AndroidStudio</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/android</string>
+        <key>NAME</key>
+        <string>AndroidStudio</string>
+        <key>VERSION_SEARCH_PATTERN</key>
+        <string>https\://redirector\.gvt1\.com/edgedl/android/studio/install/([0-9.]+)/android-studio-ide.+\.dmg</string>
+        <key>VERSION_SEARCH_URL</key>
+        <string>https://developer.android.com/sdk/index.html</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>development-android-AndroidStudio</string>
+            </array>
+            <key>category</key>
+            <string>Development</string>
+            <key>description</key>
+            <string>Android Studio is the official IDE for Android application development, based on IntelliJ IDEA.</string>
+            <key>developer</key>
+            <string>Google</string>
+            <key>display_name</key>
+            <string>Android Studio</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.novaksam.download.AndroidStudio</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Amended to grab the version from CFBundleShortVersionString

```
Processing /Users/ben/Git/foigus-recipes/Google/AndroidStudio.munki.recipe...
WARNING: /Users/ben/Git/foigus-recipes/Google/AndroidStudio.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https\\://redirector\\.gvt1\\.com/edgedl/android/studio/install/.+/android-studio-ide.+\\.dmg)',
           'url': 'https://developer.android.com/studio'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://redirector.gvt1.com/edgedl/android/studio/install/4.2.0.24/android-studio-ide-202.7322048-mac.dmg
{'Output': {'match': 'https://redirector.gvt1.com/edgedl/android/studio/install/4.2.0.24/android-studio-ide-202.7322048-mac.dmg'}}
URLDownloader
{'Input': {'filename': 'AndroidStudio.dmg',
           'url': 'https://redirector.gvt1.com/edgedl/android/studio/install/4.2.0.24/android-studio-ide-202.7322048-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 04 May 2021 17:00:00 GMT
URLDownloader: Storing new ETag header: "a0c1a3"
URLDownloader: Downloaded /Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/downloads/AndroidStudio.dmg
{'Output': {'download_changed': True,
            'etag': '"a0c1a3"',
            'last_modified': 'Tue, 04 May 2021 17:00:00 GMT',
            'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/downloads/AndroidStudio.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/downloads/AndroidStudio.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/downloads/AndroidStudio.dmg/*.app',
           'requirement': 'identifier "com.google.android.studio" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'EQHXZ8M8AV'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/downloads/AndroidStudio.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.IJZxG6/Android Studio.app' matched from globbed '/private/tmp/dmg.IJZxG6/*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.IJZxG6/Android Studio.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.IJZxG6/Android Studio.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.IJZxG6/Android Studio.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/downloads/AndroidStudio.dmg',
           'pkginfo': {'catalogs': ['development-android-AndroidStudio'],
                       'category': 'Development',
                       'description': 'Android Studio is the official IDE for '
                                      'Android application development, based '
                                      'on IntelliJ IDEA.',
                       'developer': 'Google',
                       'display_name': 'Android Studio',
                       'name': 'AndroidStudio',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/android'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/android/AndroidStudio-4.2__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/android/AndroidStudio-4.2__1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'development-android-AndroidStudio',
                                                       'icon_repo_path': '',
                                                       'name': 'AndroidStudio',
                                                       'pkg_repo_path': 'apps/android/AndroidStudio-4.2__1.dmg',
                                                       'pkginfo_path': 'apps/android/AndroidStudio-4.2__1.plist',
                                                       'version': '4.2'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 5, 13, 13, 1),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'catalogs': ['development-android-AndroidStudio'],
                           'category': 'Development',
                           'description': 'Android Studio is the official IDE '
                                          'for Android application '
                                          'development, based on IntelliJ '
                                          'IDEA.',
                           'developer': 'Google',
                           'display_name': 'Android Studio',
                           'installer_item_hash': 'ff4291d56d94f5b3208f101a2591f15fef33b39e258251450916fdd62db9943e',
                           'installer_item_location': 'apps/android/AndroidStudio-4.2__1.dmg',
                           'installer_item_size': 959943,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.google.android.studio',
                                         'CFBundleName': 'Android Studio',
                                         'CFBundleShortVersionString': '4.2',
                                         'CFBundleVersion': 'AI-202.7660.26.42.7322048',
                                         'minosversion': '10.8',
                                         'path': '/Applications/Android '
                                                 'Studio.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Android '
                                                             'Studio.app'}],
                           'minimum_os_version': '10.8',
                           'name': 'AndroidStudio',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '4.2'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/android/AndroidStudio-4.2__1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/android/AndroidStudio-4.2__1.plist'}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/receipts/AndroidStudio.munki-receipt-20210513-140101.plist

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    /Users/ben/Library/AutoPkg/Cache/com.github.foigus.munki.AndroidStudio/downloads/AndroidStudio.dmg  

The following new items were imported into Munki:
    Name           Version  Catalogs                           Pkginfo Path                             Pkg Repo Path                          Icon Repo Path  
    ----           -------  --------                           ------------                             -------------                          --------------  
    AndroidStudio  4.2      development-android-AndroidStudio  apps/android/AndroidStudio-4.2__1.plist  apps/android/AndroidStudio-4.2__1.dmg                  
```