### PR TITLE
Update GoogleChromeCanary.download.recipe

### DIFF
--- a/Google/GoogleChromeCanary.download.recipe
+++ b/Google/GoogleChromeCanary.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://dl.google.com/release2/q/canary/googlechrome.dmg</string>
+		<string>https://dl.google.com/chrome/mac/universal/canary/googlechromecanary.dmg</string>
 		<key>NAME</key>
 		<string>GoogleChromeCanary</string>
 	</dict>


### PR DESCRIPTION
The old `DOWNLOAD_URL` pulls version `98.0.4707.0`, while the updated pulls the latest version (`98.0.4752.0`) as of today.