### PR TITLE
Update Developer signing ID

### DIFF
--- a/Maxon/TrapcodeSuite.download.recipe
+++ b/Maxon/TrapcodeSuite.download.recipe
@@ -67,7 +67,7 @@
 				<key>input_path</key>
 				<string>%found_filename%</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.redgiant.Trapcode-Suite-Installer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D642JS68SL)</string>
+				<string>anchor apple generic and identifier "com.redgiant.Trapcode-Suite-Installer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4ZY22YGXQG")</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Runs of the Trapcode.munki recipe result in an error of:
```
Error in local.munki.TrapcodeSuite: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
```

Comparing an older version of the installer to the latest version downloaded by autopkg, the code sign signature has changed.  This PR updates to match the current signing ID.