### PR TITLE
update api version in Wrike.download.recipe

### DIFF
--- a/Wrike/Wrike.download.recipe
+++ b/Wrike/Wrike.download.recipe
@@ -21,7 +21,7 @@
 				<key>re_pattern</key>
 				<string>https://.*\.dmg</string>
 				<key>url</key>
-				<string>https://www.wrike.com/api/v3/internal/integration_info?type=WrikeDesktopMac</string>
+				<string>https://www.wrike.com/api/v4/internal/integration_info?type=WrikeDesktopMac</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
v3 to v4, see Wrike's article [Migration from API v3](https://developers.wrike.com/migration-from-api-v3/)
confirmed change works on AutoPkg 2.3.1 / JSSImporter 1.1.6