### PR TITLE
Update Cinema4DSubscription.munki.recipe

### DIFF
--- a/Maxon/Cinema4DSubscription.munki.recipe
+++ b/Maxon/Cinema4DSubscription.munki.recipe
@@ -27,7 +27,7 @@ autopkg repo-add homebysix-recipes</string>
 rm -rf /Applications/Maxon\ Cinema\ 4D\ S%MAJOR_VERSION%
 
 #Forget the package receipt
-pkgutil --forget com.maxon.Cinema4D-S%MAJOR_VERSION%.pkg</string>
+pkgutil --forget com.maxon.Cinema4DSubscription-S%MAJOR_VERSION%.pkg</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>


### PR DESCRIPTION
Hi, @foigus 

This PR has an updated `uninstall_script` that removes the package receipt.

```
managedsoftwareupdate --installonly
Managed Software Update Tool
Copyright 2010-2021 The Munki Project
https://github.com/munki/munki

Starting...
    Preventing idle sleep
Removing Cinema 4D Subscription (1 of 1)...
    Running uninstall_script for Cinema4DSubscription...
    No receipt for 'com.maxon.Cinema4D-S26.pkg' found at '/'.
ERROR: Running uninstall_script for Cinema4DSubscription failed.
ERROR: ------------------------------------------------------------------------------
ERROR: 	No receipt for 'com.maxon.Cinema4D-S26.pkg' found at '/'.
ERROR: ------------------------------------------------------------------------------
    Allowing idle sleep
Finishing...
Done.
```
```
pkgutil --pkgs
com.maxon.Cinema4DSubscription-S26.pkg
```
