### PR TITLE
Update code signature for Teradici PCoIP client

### DIFF
--- a/Teradici/TeradiciClient.download.recipe
+++ b/Teradici/TeradiciClient.download.recipe
@@ -53,7 +53,7 @@
 				<key>input_path</key>
 				<string>%pathname%/PCoIPClient.app</string>
 				<key>requirement</key>
-				<string>identifier "com.teradici.swiftclient" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = RU4LW7W32C</string>
+				<string>identifier "com.teradici.pcoipclient" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = RU4LW7W32C</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Before change:

```
% autopkg run -vv 'foigus-recipes/Teradici/TeradiciClient.download.recipe'
Processing foigus-recipes/Teradici/TeradiciClient.download.recipe...
WARNING: foigus-recipes/Teradici/TeradiciClient.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 28 Sep 2022 15:28:23 GMT
URLDownloader: Storing new ETag header: "67b636ecdc702d7db192453bec95cfbf-3"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg
{'Output': {'download_changed': True,
            'etag': '"67b636ecdc702d7db192453bec95cfbf-3"',
            'last_modified': 'Wed, 28 Sep 2022 15:28:23 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
URLTextSearcher
{'Input': {'curl_opts': ['--head'],
           're_pattern': 'filename="pcoip-client_([\\d\\.]+).dmg"',
           'result_output_var_name': 'version',
           'url': 'https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg'}}
URLTextSearcher: Found matching text (version): 22.09.1
{'Output': {'version': '22.09.1'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg/PCoIPClient.app',
           'requirement': 'identifier "com.teradici.swiftclient" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'RU4LW7W32C'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.rbX9n5/PCoIPClient.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.rbX9n5/PCoIPClient.app: satisfies its Designated Requirement
CodeSignatureVerifier: test-requirement: code failed to satisfy specified code requirement(s)
Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/receipts/TeradiciClient.download-receipt-20221006-100415.plist

The following recipes failed:
    foigus-recipes/Teradici/TeradiciClient.download.recipe
        Error in com.github.foigus.download.teradiciclient: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    ~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg  
```

After change:

```
% autopkg run -vv 'foigus-recipes/Teradici/TeradiciClient.download.recipe'
Processing foigus-recipes/Teradici/TeradiciClient.download.recipe...
WARNING: foigus-recipes/Teradici/TeradiciClient.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg'}}
URLTextSearcher
{'Input': {'curl_opts': ['--head'],
           're_pattern': 'filename="pcoip-client_([\\d\\.]+).dmg"',
           'result_output_var_name': 'version',
           'url': 'https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg'}}
URLTextSearcher: Found matching text (version): 22.09.1
{'Output': {'version': '22.09.1'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg/PCoIPClient.app',
           'requirement': 'identifier "com.teradici.pcoipclient" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'RU4LW7W32C'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/downloads/pcoip-client_latest.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.CJspdQ/PCoIPClient.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.CJspdQ/PCoIPClient.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.CJspdQ/PCoIPClient.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foigus.download.teradiciclient/receipts/TeradiciClient.download-receipt-20221006-100534.plist

Nothing downloaded, packaged or imported.
```