### PR TITLE
Update AndroidStudio.munki.recipe

### DIFF
--- a/Google/AndroidStudio.munki.recipe
+++ b/Google/AndroidStudio.munki.recipe
@@ -32,6 +32,10 @@ autopkg repo-add novaksam-recipes</string>
 			<string>Android Studio</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%SUPPORTED_ARCH%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Adds a `supported_architectures` array that pulls the variable from the upstream download recipe.