### PR TITLE
Update i1Studio.munki.recipe

### DIFF
--- a/X-Rite/i1Studio.munki.recipe
+++ b/X-Rite/i1Studio.munki.recipe
@@ -5,11 +5,15 @@
 	<key>Comment</key>
 	<string>Originally created with Recipe Robot v1.2.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of i1Studio and imports it into Munki.</string>
+	<string>Downloads the latest version of i1Studio and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.foigus.munki.i1Studio</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/xrite</string>
 		<key>NAME</key>
@@ -35,7 +39,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.foigus.download.i1Studio</string>
 	<key>Process</key>
@@ -77,6 +81,8 @@
 				</array>
 				<key>version_comparison_key</key>
 				<string>CFBundleShortVersionString</string>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>


### PR DESCRIPTION
Hi, @foigus 

The i1Studio Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.13

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/foigus-recipes/X-Rite/i1Studio.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/foigus-recipes/X-Rite/i1Studio.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/foigus-recipes/X-Rite/i1Studio.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.6.0.14916
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.6.0
SparkleUpdateInfoProvider: Found URL http://downloads.xrite.com/Downloads/Software/i1Studio/v1.6.0/mac/i1Studio.zip
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 19 May 2021 14:25:02 GMT
URLDownloader: Storing new ETag header: "0b337c1ba4cd71:0"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/downloads/i1Studio.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename i1Studio.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/downloads/i1Studio.zip to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/unarchive
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "i1Studio.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-19 14:11:11 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: X-Rite, Incorporated (2K7GT73B4R)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            33 C2 61 37 C3 FE A0 5E 10 83 E4 21 23 51 78 9F FD DC E2 77 7F A1 
CodeSignatureVerifier:            09 F2 95 4F AB D9 5C DB 6B CA
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/unarchive/i1Studio.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/pkgroot
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/pkgroot/i1Studio.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/unpack
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/i1Studio/i1Studio.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.13
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.x-rite.i1Studio', 'CFBundleName': 'i1Studio', 'CFBundleShortVersionString': '1.6.0', 'CFBundleVersion': '1.6.0.14916', 'minosversion': '10.13', 'path': '/Applications/i1Studio/i1Studio.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.13'} into pkginfo
Versioner
Versioner: Found version 1.6.0 in file /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/unpack/Applications/i1Studio/i1Studio.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '1.6.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/xrite/i1Studio-1.6.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/xrite/i1Studio-1.6.0.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/pkgroot
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/unarchive
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/unpack
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/receipts/i1Studio.munki-receipt-20221221-095958.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.i1Studio/downloads/i1Studio.zip  

The following new items were imported into Munki:
    Name      Version  Catalogs                    Pkginfo Path                     Pkg Repo Path                  Icon Repo Path  
    ----      -------  --------                    ------------                     -------------                  --------------  
    i1Studio  1.6.0    development-xrite-i1Studio  apps/xrite/i1Studio-1.6.0.plist  apps/xrite/i1Studio-1.6.0.pkg
```