### PR TITLE
Update TableauReader.munki.recipe

### DIFF
--- a/Tableau/TableauReader.munki.recipe
+++ b/Tableau/TableauReader.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Tableau Reader disk image and imports it into Munki.</string>
+	<string>Downloads latest Tableau Reader disk image and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.foigus.munki.tableau-reader</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/tableau</string>
 		<key>NAME</key>
@@ -30,8 +34,6 @@
 			<string>Tableau</string>
 			<key>display_name</key>
 			<string>Tableau Reader</string>
-			<key>minimum_os_version</key>
-			<string>10.11</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -39,7 +41,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.foigus.download.tableau-reader</string>
 	<key>Process</key>
@@ -61,7 +63,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/Tableau App.pkg/payload</string>
 				<key>purge_destination</key>
@@ -74,10 +76,31 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Tableau Reader*.app</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/Tableau Reader*.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/%found_basename%</string>
+				</array>
+				<key>version_comparison_key</key>
+				<string>CFBundleShortVersionString</string>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -115,6 +138,18 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		 <dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/Applications</string>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @foigus 

The TableauReader Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in `MunkiInstallsItemsCreator` with support for the new `derive_minimum_os_version` key in the processor. With this set the `min_os_version` becomes 10.14

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

`PathDeleter` has also been added to tidy up after.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/foigus-recipes/Tableau/TableauReader.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/foigus-recipes/Tableau/TableauReader.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/foigus-recipes/Tableau/TableauReader.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 13 Dec 2022 23:09:18 GMT
URLDownloader: Storing new ETag header: "b8d4d1743c12e52adce1109e3501be84:1670972963.96019"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/downloads/TableauReader.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/downloads/TableauReader.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Tableau Reader.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-18 16:26:28 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)
CodeSignatureVerifier:        Expires: 2025-05-30 14:49:09 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            A8 6F 53 17 62 1F D4 C7 F5 1B 2A 5A 9C 2A 1B B9 29 AF B3 79 DF 18 
CodeSignatureVerifier:            48 1D 35 5A EE 9F 21 02 EC 82
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/downloads/TableauReader.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.3YdqSO/Tableau Reader.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/unpack/Tableau App.pkg/payload to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/Applications
FileFinder
FileFinder: Found file match: '/Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/Applications/Tableau Reader 2022.4.app' from globbed '/Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/Applications/Tableau Reader*.app'
FileFinder: Basename match: 'Tableau Reader 2022.4.app'
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Tableau Reader 2022.4.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.14
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.tableausoftware.tableaureader', 'CFBundleName': 'Tableau Reader', 'CFBundleShortVersionString': '2022.4.0', 'CFBundleVersion': '20224.22.1117.1841', 'minosversion': '10.14', 'path': '/Applications/Tableau Reader 2022.4.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.14'} into pkginfo
PlistReader
PlistReader: Reading: /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/Applications/Tableau Reader 2022.4.app/Contents/Info.plist
PlistReader: Assigning value of '2022.4.0' to output variable 'version'
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2022.4.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/tableau/TableauReader-2022.4.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/tableau/TableauReader-2022.4.0.dmg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/Applications
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/unpack
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/receipts/TableauReader.munki-receipt-20230117-131935.plist

The following new items were downloaded:
    Download Path                                                                                         
    -------------                                                                                         
    /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.tableau-reader/downloads/TableauReader.dmg  

The following new items were imported into Munki:
    Name           Version   Catalogs                           Pkginfo Path                               Pkg Repo Path                            Icon Repo Path  
    ----           -------   --------                           ------------                               -------------                            --------------  
    TableauReader  2022.4.0  development-tableau-TableauReader  apps/tableau/TableauReader-2022.4.0.plist  apps/tableau/TableauReader-2022.4.0.dmg
```
