### PR TITLE
Update CaptureOne.download.recipe

### DIFF
--- a/PhaseOne/CaptureOne.download.recipe
+++ b/PhaseOne/CaptureOne.download.recipe
@@ -34,7 +34,7 @@ NOTES:
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>&lt;AvailableVersion&gt;(%ACTUAL_VERSION%[\.\d]*)&lt;\/AvailableVersion&gt;</string>
+				<string>&lt;AvailableVersion&gt;(%ACTUAL_VERSION%\.\d\.\d)\.[0-9]+&lt;/AvailableVersion&gt;</string>
 				<key>result_output_var_name</key>
 				<string>truncated_version</string>
 				<key>url</key>
@@ -49,7 +49,7 @@ NOTES:
 				<key>filename</key>
 				<string>CaptureOne.dmg</string>
 				<key>url</key>
-				<string>https://downloads.phaseone.com/%DOWNLOADURLUUID%/%LANGUAGE%/CaptureOne%MARKETING_VERSION%.Mac.%truncated_version%.dmg</string>
+				<string>https://downloads.phaseone.com/%DOWNLOADURLUUID%/%LANGUAGE%/CaptureOne%MARKETING_VERSION%Mac%truncated_version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hi, @foigus 

The latest CaptureOne release has changed the format of the download url by not including the full version number. 

This PR has updated regex and download url to reflect. 

Output from a successful -vv run

```
autopkg run -vv /Users/paul/Documents/GitHub/AutoPkg\ Repos/foigus-recipes/PhaseOne/CaptureOnePerpetual.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/foigus-recipes/PhaseOne/CaptureOnePerpetual.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/foigus-recipes/PhaseOne/CaptureOnePerpetual.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<AvailableVersion>(16\\.\\d\\.\\d)\\.[0-9]+</AvailableVersion>',
           'result_output_var_name': 'truncated_version',
           'url': 'https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=8.0'}}
URLTextSearcher: Found matching text (truncated_version): 16.0.2
{'Output': {'truncated_version': '16.0.2'}}
URLDownloader
{'Input': {'filename': 'CaptureOne.dmg',
           'url': 'https://downloads.phaseone.com/fe066656-a98c-45bf-999b-b8e4a7da1b2c/International/CaptureOne23Mac16.0.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 17 Jan 2023 13:03:50 GMT
URLDownloader: Storing new ETag header: "e57ae7a13e246b81a93e6dd4013acfc3:1673960630.225728"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg
{'Output': {'download_changed': True,
            'etag': '"e57ae7a13e246b81a93e6dd4013acfc3:1673960630.225728"',
            'last_modified': 'Tue, 17 Jan 2023 13:03:50 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg/Capture '
                         'One 23.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.captureone.captureone16" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5WTDB5F65L")'}}
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.MkMUI2/Capture One 23.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.MkMUI2/Capture One 23.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.MkMUI2/Capture One 23.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
StopProcessingIf
{'Input': {'predicate': 'download_changed == FALSE AND STOP_ON_NO_NEW_DOWNLOAD '
                        '== TRUE'}}
StopProcessingIf: (download_changed == FALSE AND STOP_ON_NO_NEW_DOWNLOAD == TRUE) is False
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'force_munkiimport': 'totally',
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg',
           'pkginfo': {'catalogs': ['development-phaseone-CaptureOne23'],
                       'category': 'Productivity',
                       'description': 'The professional choice in imaging '
                                      'software.',
                       'developer': 'Phase One',
                       'display_name': 'Capture One 23',
                       'name': 'CaptureOne23',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/phaseone'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/phaseone/CaptureOne23-16.0.2.21__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/phaseone/CaptureOne-16.0.2.21__1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'development-phaseone-CaptureOne23',
                                                       'icon_repo_path': '',
                                                       'name': 'CaptureOne23',
                                                       'pkg_repo_path': 'apps/phaseone/CaptureOne-16.0.2.21__1.dmg',
                                                       'pkginfo_path': 'apps/phaseone/CaptureOne23-16.0.2.21__1.plist',
                                                       'version': '16.0.2.21'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2023, 1, 18, 14, 2, 44),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '13.1'},
                           'autoremove': False,
                           'catalogs': ['development-phaseone-CaptureOne23'],
                           'category': 'Productivity',
                           'description': 'The professional choice in imaging '
                                          'software.',
                           'developer': 'Phase One',
                           'display_name': 'Capture One 23',
                           'installer_item_hash': '117d60fbf27098731646c691d4c6bc7ee72de9483de9ebaee7fa6842f6b73da4',
                           'installer_item_location': 'apps/phaseone/CaptureOne-16.0.2.21__1.dmg',
                           'installer_item_size': 696723,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.captureone.captureone16',
                                         'CFBundleName': 'Capture One',
                                         'CFBundleShortVersionString': '16.0.2.21',
                                         'CFBundleVersion': '16.0.2.21',
                                         'minosversion': '10.15',
                                         'path': '/Applications/Capture One '
                                                 '23.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Capture One '
                                                             '23.app'}],
                           'minimum_os_version': '10.15',
                           'name': 'CaptureOne23',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '16.0.2.21'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/phaseone/CaptureOne-16.0.2.21__1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/phaseone/CaptureOne23-16.0.2.21__1.plist'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/receipts/CaptureOnePerpetual.munki-receipt-20230118-140245.plist

The following new items were downloaded:
    Download Path                                                                                  
    -------------                                                                                  
    /Users/paul/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg  

The following new items were imported into Munki:
    Name          Version    Catalogs                           Pkginfo Path                                   Pkg Repo Path                              Icon Repo Path  
    ----          -------    --------                           ------------                                   -------------                              --------------  
    CaptureOne23  16.0.2.21  development-phaseone-CaptureOne23  apps/phaseone/CaptureOne23-16.0.2.21__1.plist  apps/phaseone/CaptureOne-16.0.2.21__1.dmg
```