### PR TITLE
Update Assets Plugin and Woodwing Studio recipes for InDesign CC 2023

### DIFF
--- a/WoodWing/Assets Scripts InDesign 2023/Fixed Scripts/Uninstall WoodWing Assets for InDesign
+++ b/WoodWing/Assets Scripts InDesign 2023/Fixed Scripts/Uninstall WoodWing Assets for InDesign
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+##Double pound signs are edits from Patrick Fergus
+#---------------------------------------------------------------------
+# Declare the path finding variables.
+
+# Get the absolute path to this very script with script name and extension.
+# To get the path only, detract the directory name.
+##Don't need to find the application folder to uninstall from, let's hard-code this
+##path_only=`dirname "${0}"`
+##path_only=`dirname "${path_only}"`
+##path_only=`dirname "${path_only}"`
+##path_only=`dirname "${path_only}"`
+path_only="/Applications/Adobe InDesign 2023"
+
+# Boolean to show message on success.
+B_MSG=true
+
+# Ask the user for the administrator username and password.
+# IF the user cancels then nothing will be done.
+##Don't need this any more, there is no choice.  Let's hard-code this
+##UNINSTALL_WOODWINGASSETSFORINDESIGN_APP=$(osascript \
+##								-e	'set the_results to ""' \
+##								-e	'try' \
+##								-e		'tell application "Finder"' \
+##								-e		'activate' \
+##								-e		'set the_results to ((display dialog "You are about to remove all WoodWing Assets for InDesign files, including the WoodWing Assets InDesign.app.\nWhen you have multiple installations of WoodWing Assets for InDesign on your system, you might want to leave this file on your system.\n\nDo you want to remove the WoodWing Assets InDesign.app?" with title "Uninstall WoodWing Assets InDesign" buttons {"Yes", "No"} default button 2))' \
+##								-e		'end tell' \
+##								-e	'end try' \
+##								-e 'return {the_results}')
+
+##Set Woodwing Assets App to NOT be uninstalled
+UNINSTALL_WOODWINGASSETSFORINDESIGN_APP=":No"
+
+echo "USER ACTION: ${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}"
+echo ""
+
+if [[ "${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}" == *":Yes"* ]]; then
+##	# Ask the user for the administrator username and password.
+##	# IF the user cancels then nothing will be done.
+##	# The script will set some access rights and
+##	# the script will remove the WoodWing Assets InDesign.app
+##	DO_SUDO=$(osascript \
+##				-e	'set the_password to ""' \
+##				-e	'try' \
+##				-e		'tell application "Finder"' \
+##				-e			'set the_username to do shell script "whoami"' \
+##				-e			'set the_password to ""' \
+##				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/Elvis\" password the_password with administrator privileges" \
+##				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/WoodWing\" password the_password with administrator privileges" \
+##				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app\"" password the_password with administrator privileges' \
+##				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app/Contents\"" password the_password with administrator privileges' \
+##	        	-e 			'do shell script "sudo rm -rf \"/Applications/WoodWing Assets InDesign.app\"" password the_password with administrator privileges' \
+##				-e			'set the_password to "1"' \
+##				-e		'end tell' \
+##				-e	'on error number -128' \
+##				-e		'set the_password to "0"' \
+##				-e	'end try' \
+##				-e 'return {the_password}')
+
+##Removing WoodWing Assets InDesign App via a shell script
+	rm -rf "/Applications/WoodWing Assets InDesign.app"
+
+	echo "USER ACTION: ${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}"
+	echo ""
+
+	# Check if the user has canceled (0) or not (1).
+	if [ "${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}" == "0" ]; then
+		echo "${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}"
+		exit 1;
+	else
+		echo "NO CANCEL"
+	fi
+else
+##No need to do this--the script is already running with elevated privileges
+##	# Ask the user for the administrator username and password.
+##	# IF the user cancels then nothing will be done.
+##	# The script will set some access rights.
+##	DO_SUDO=$(osascript \
+##				-e	'set the_password to ""' \
+##				-e	'try' \
+##				-e		'tell application "Finder"' \
+##				-e			'set the_username to do shell script "whoami"' \
+##				-e			'set the_password to ""' \
+##				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/Elvis\" password the_password with administrator privileges" \
+##				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/WoodWing\" password the_password with administrator privileges" \
+##				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app\"" password the_password with administrator privileges' \
+##				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app/Contents\"" password the_password with administrator privileges' \
+##				-e			'set the_password to "1"' \
+##				-e		'end tell' \
+##				-e	'on error number -128' \
+##				-e		'set the_password to "0"' \
+##				-e	'end try' \
+##				-e 'return {the_password}')
+##
+##	echo "USER ACTION: ${DO_SUDO}"
+	echo ""
+
+##No need to check whether the user cancelled--we never entered the code where it matters
+##	# Check if the user has canceled (0) or not (1).
+##	if [ "${DO_SUDO}" == "0" ]; then
+##		echo "${DO_SUDO}"
+##		exit 1;
+##	else
+##		echo "NO CANCEL"
+##	fi
+fi
+
+
+#---------------------------------------------------------------------
+# Remove plugins.
+
+function UninstallPlugins()
+{
+	# Delete the whole 'Plug-Ins/Elvis' folder.
+	#	echo " Deleting the Elvis Folder"
+	if [ -d "${path_only}/Plug-Ins/Elvis" ]; then
+		rm -rf "${path_only}/Plug-Ins/Elvis"
+	fi
+
+	# Delete the WoodWingCommon plugins.
+	if [ -d "${path_only}/Plug-Ins/WoodWing" ]; then
+
+		# Find and remopve all the WoodwingCommon plugins.
+		find "${path_only}/Plug-Ins/WoodWing" \
+				-maxdepth "1" \
+				\( -iname "WoodWingCommon*.InDesignPlugin" \) \
+				-exec echo "  Deleting {}" \; \
+				-exec rm -rf {} \;
+
+		# Find and remopve all the WoodwingCommon plugins.
+		find "${path_only}/Plug-Ins/WoodWing" \
+				-maxdepth "1" \
+				\( -iname "Assets*.InDesignPlugin" \) \
+				-exec echo "  Deleting {}" \; \
+				-exec rm -rf {} \;
+
+		# Delete the whole 'Plug-Ins/WoodWing' folder if it is empty.
+		rmdir "${path_only}/Plug-Ins/WoodWing"
+	fi
+}
+
+
+#---------------------------------------------------------------------
+# Remove the Elvis InDesign installer log files.
+
+function UninstallInstallerLogs()
+{
+	if [ -f "/private/tmp/WWAssetsInDesignInstallCheck.log" ]; then
+		:> "/private/tmp/WWAssetsInDesignInstallCheck.log"
+		rm -rf "/private/tmp/WWAssetsInDesignInstallCheck.log"
+	fi
+
+	if [ -f "/private/tmp/WWAssetsInDesignInstaller.log" ]; then
+		:> "/private/tmp/WWAssetsInDesignInstaller.log"
+		rm -rf "/private/tmp/WWAssetsInDesignInstaller.log"
+	fi
+}
+
+# Remove all package IDs
+#function UninstallPackageIDs()
+
+
+#---------------------------------------------------------------------
+# Main script.
+
+# Delete the 'Plug-Ins/Elvis' folder and its content.
+UninstallPlugins
+
+UninstallInstallerLogs
+
+#UninstallPackageIDs
+
+# Show a message to the user on success.
+##Want this to be silent--removing this bit of UI
+##if [ $B_MSG == true ]; then
+##	osascript \
+##	-e 'with timeout of 1800 seconds' \
+##	-e 	'tell application "Finder"' \
+##	-e	'activate' \
+##	-e		'display dialog "WoodWing Assets for InDesign has been succesfully removed." with title "Uninstall WoodWing Assets for InDesign" buttons {"OK"}' \
+##	-e 	'end tell' \
+##	-e 'end timeout'
+##fi
+
+# Remove the uninstaller.
+##Another hard path here
+##new_path_only=`dirname "${0}"`
+##new_path_only=`dirname "${new_path_only}"`
+##new_path_only=`dirname "${new_path_only}"`
+new_path_only="/Applications/Adobe InDesign 2023/Uninstall WoodWing Assets for InDesign.app"
+#echo "New path only: ${new_path_only}"
+
+# Delete the uninstaller app if it exists in the found path name.
+if [[ "${new_path_only}" == *"Uninstall WoodWing Assets for InDesign.app"* ]]; then
+	rm -rf "${new_path_only}"
+fi
+
+exit 0

--- a/WoodWing/Assets Scripts InDesign 2023/My Scripts/Forget InDesign Receipts 2023.sh
+++ b/WoodWing/Assets Scripts InDesign 2023/My Scripts/Forget InDesign Receipts 2023.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+receiptOne=com.woodwing.pkg.assets.id2023
+receiptTwo=com.woodwing.pkg.payload
+
+if pkgutil --pkgs="${receiptOne}" 2>&1 > /dev/null
+then
+	pkgutil --forget "${receiptOne}"
+fi
+
+if pkgutil --pkgs="${receiptTwo}" 2>&1 > /dev/null
+then
+	pkgutil --forget "${receiptTwo}"
+fi

--- a/WoodWing/Assets Scripts InDesign 2023/Original Woodwing Scripts/Uninstall WoodWing Assets for InDesign
+++ b/WoodWing/Assets Scripts InDesign 2023/Original Woodwing Scripts/Uninstall WoodWing Assets for InDesign
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+#---------------------------------------------------------------------
+# Declare the path finding variables.
+
+# Get the absolute path to this very script with script name and extension.
+# To get the path only, detract the directory name.
+path_only=`dirname "${0}"`
+path_only=`dirname "${path_only}"`
+path_only=`dirname "${path_only}"`
+path_only=`dirname "${path_only}"`
+
+# Boolean to show message on success.
+B_MSG=true
+
+# Ask the user for the administrator username and password.
+# IF the user cancels then nothing will be done.
+UNINSTALL_WOODWINGASSETSFORINDESIGN_APP=$(osascript \
+								-e	'set the_results to ""' \
+								-e	'try' \
+								-e		'tell application "Finder"' \
+								-e		'activate' \
+								-e		'set the_results to ((display dialog "You are about to remove all WoodWing Assets for InDesign files, including the WoodWing Assets InDesign.app.\nWhen you have multiple installations of WoodWing Assets for InDesign on your system, you might want to leave this file on your system.\n\nDo you want to remove the WoodWing Assets InDesign.app?" with title "Uninstall WoodWing Assets InDesign" buttons {"Yes", "No"} default button 2))' \
+								-e		'end tell' \
+								-e	'end try' \
+								-e 'return {the_results}')
+
+echo "USER ACTION: ${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}"
+echo ""
+
+if [[ "${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}" == *":Yes"* ]]; then
+	# Ask the user for the administrator username and password.
+	# IF the user cancels then nothing will be done.
+	# The script will set some access rights and
+	# the script will remove the WoodWing Assets InDesign.app
+	DO_SUDO=$(osascript \
+				-e	'set the_password to ""' \
+				-e	'try' \
+				-e		'tell application "Finder"' \
+				-e			'set the_username to do shell script "whoami"' \
+				-e			'set the_password to ""' \
+				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/Elvis\" password the_password with administrator privileges" \
+				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/WoodWing\" password the_password with administrator privileges" \
+				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app\"" password the_password with administrator privileges' \
+				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app/Contents\"" password the_password with administrator privileges' \
+	        	-e 			'do shell script "sudo rm -rf \"/Applications/WoodWing Assets InDesign.app\"" password the_password with administrator privileges' \
+				-e			'set the_password to "1"' \
+				-e		'end tell' \
+				-e	'on error number -128' \
+				-e		'set the_password to "0"' \
+				-e	'end try' \
+				-e 'return {the_password}')
+
+	echo "USER ACTION: ${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}"
+	echo ""
+
+	# Check if the user has canceled (0) or not (1).
+	if [ "${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}" == "0" ]; then
+		echo "${UNINSTALL_WOODWINGASSETSFORINDESIGN_APP}"
+		exit 1;
+	else
+		echo "NO CANCEL"
+	fi
+else
+	# Ask the user for the administrator username and password.
+	# IF the user cancels then nothing will be done.
+	# The script will set some access rights.
+	DO_SUDO=$(osascript \
+				-e	'set the_password to ""' \
+				-e	'try' \
+				-e		'tell application "Finder"' \
+				-e			'set the_username to do shell script "whoami"' \
+				-e			'set the_password to ""' \
+				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/Elvis\" password the_password with administrator privileges" \
+				-e 			"do shell script \"sudo chmod -R 777 '$path_only'/Plug-Ins/WoodWing\" password the_password with administrator privileges" \
+				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app\"" password the_password with administrator privileges' \
+				-e 			'do shell script "sudo chmod -R 777 \"/Applications/WoodWing Assets InDesign.app/Contents\"" password the_password with administrator privileges' \
+				-e			'set the_password to "1"' \
+				-e		'end tell' \
+				-e	'on error number -128' \
+				-e		'set the_password to "0"' \
+				-e	'end try' \
+				-e 'return {the_password}')
+
+	echo "USER ACTION: ${DO_SUDO}"
+	echo ""
+
+	# Check if the user has canceled (0) or not (1).
+	if [ "${DO_SUDO}" == "0" ]; then
+		echo "${DO_SUDO}"
+		exit 1;
+	else
+		echo "NO CANCEL"
+	fi
+fi
+
+
+#---------------------------------------------------------------------
+# Remove plugins.
+
+function UninstallPlugins()
+{
+	# Delete the whole 'Plug-Ins/Elvis' folder.
+	#	echo " Deleting the Elvis Folder"
+	if [ -d "${path_only}/Plug-Ins/Elvis" ]; then
+		rm -rf "${path_only}/Plug-Ins/Elvis"
+	fi
+
+	# Delete the WoodWingCommon plugins.
+	if [ -d "${path_only}/Plug-Ins/WoodWing" ]; then
+
+		# Find and remopve all the WoodwingCommon plugins.
+		find "${path_only}/Plug-Ins/WoodWing" \
+				-maxdepth "1" \
+				\( -iname "WoodWingCommon*.InDesignPlugin" \) \
+				-exec echo "  Deleting {}" \; \
+				-exec rm -rf {} \;
+
+		# Find and remopve all the WoodwingCommon plugins.
+		find "${path_only}/Plug-Ins/WoodWing" \
+				-maxdepth "1" \
+				\( -iname "Assets*.InDesignPlugin" \) \
+				-exec echo "  Deleting {}" \; \
+				-exec rm -rf {} \;
+
+		# Delete the whole 'Plug-Ins/WoodWing' folder if it is empty.
+		rmdir "${path_only}/Plug-Ins/WoodWing"
+	fi
+}
+
+
+#---------------------------------------------------------------------
+# Remove the Elvis InDesign installer log files.
+
+function UninstallInstallerLogs()
+{
+	if [ -f "/private/tmp/WWAssetsInDesignInstallCheck.log" ]; then
+		:> "/private/tmp/WWAssetsInDesignInstallCheck.log"
+		rm -rf "/private/tmp/WWAssetsInDesignInstallCheck.log"
+	fi
+
+	if [ -f "/private/tmp/WWAssetsInDesignInstaller.log" ]; then
+		:> "/private/tmp/WWAssetsInDesignInstaller.log"
+		rm -rf "/private/tmp/WWAssetsInDesignInstaller.log"
+	fi
+}
+
+# Remove all package IDs
+#function UninstallPackageIDs()
+
+
+#---------------------------------------------------------------------
+# Main script.
+
+# Delete the 'Plug-Ins/Elvis' folder and its content.
+UninstallPlugins
+
+UninstallInstallerLogs
+
+#UninstallPackageIDs
+
+# Show a message to the user on success.
+if [ $B_MSG == true ]; then
+	osascript \
+	-e 'with timeout of 1800 seconds' \
+	-e 	'tell application "Finder"' \
+	-e	'activate' \
+	-e		'display dialog "WoodWing Assets for InDesign has been succesfully removed." with title "Uninstall WoodWing Assets for InDesign" buttons {"OK"}' \
+	-e 	'end tell' \
+	-e 'end timeout'
+fi
+
+# Remove the uninstaller.
+new_path_only=`dirname "${0}"`
+new_path_only=`dirname "${new_path_only}"`
+new_path_only=`dirname "${new_path_only}"`
+#echo "New path only: ${new_path_only}"
+
+# Delete the uninstaller app if it exists in the found path name.
+if [[ "${new_path_only}" == *"Uninstall WoodWing Assets for InDesign.app"* ]]; then
+	rm -rf "${new_path_only}"
+fi
+
+exit 0

--- a/WoodWing/AssetsInDesignCC2023Plugin.munki.recipe
+++ b/WoodWing/AssetsInDesignCC2023Plugin.munki.recipe
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads Assets Plugin and imports it into Munki for installation for InDesign 2023.
+
+NOTES:
+- This recipe depends on hjuutilainen's ChecksumVerifier.  Add this repo via:
+
+autopkg repo-add hjuutilainen-recipes
+
+- Specific pkgs are enabled via InstallerChoices depending on the product that's being installed.  Due to this, the packages are identical--thus force_munkiimport is set to true
+- This recipe does not download the Assets package--feed the package into the recipe via the following format:
+
+autopkg run AssetsInDesignCC2023Plugin.munki -p /path/WoodWing\ Assets\ for\ InDesign.pkg</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.munki.AssetsInDesignCC2023Plugin</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>plugins/woodwing</string>
+		<key>NAME</key>
+		<string>AssetsInDesignCC2023Plugin</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>Comment</key>
+			<string>Choice is installer_choice_1 (as of Assets 4.6.2, this is "Assets for InDesign 2023")</string>
+			<key>blocking_applications</key>
+			<array>
+				<string>Adobe InDesign 2023</string>
+			</array>
+			<key>catalogs</key>
+			<array>
+				<string>development-woodwing-AssetsInDesignCC2023Plugin</string>
+			</array>
+			<key>category</key>
+			<string>Plugins</string>
+			<key>description</key>
+			<string>WoodWing Assets helps you create incredible assets and enables creatives to collaborate more effectively. All files are stored in a single location, giving you maximum control over when and where assets are used.</string>
+			<key>developer</key>
+			<string>Woodwing</string>
+			<key>display_name</key>
+			<string>Assets InDesign 2023</string>
+			<key>installer_choices_xml</key>
+			<array>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>installer_choice_1</string>
+				</dict>
+			</array>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>requires</key>
+			<array>
+				<string>InDesignCC2023</string>
+			</array>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.foigus.download.AssetsInDesignPlugin</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>flat_pkg_path</key>
+				<string>%PKG%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Comment</key>
+			<string>Unpack the original package</string>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>algorithm</key>
+				<string>MD5</string>
+				<key>checksum</key>
+				<string>5b090ab28bc7316d447625b19b1d4293</string>
+				<key>pathname</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Assets for InDesign.app/Contents/MacOS/Uninstall WoodWing Assets for InDesign</string>
+			</dict>
+			<key>Comment</key>
+			<string>Verify MD5 matches 4.5.0.944 on the uninstall script</string>
+			<key>Processor</key>
+			<string>io.github.hjuutilainen.SharedProcessors/ChecksumVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>algorithm</key>
+				<string>MD5</string>
+				<key>checksum</key>
+				<string>c3c810b0a6dd92a271aa01f02812ca74</string>
+				<key>pathname</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/ASSETSID2023.pkg/Scripts/postinstall</string>
+			</dict>
+			<key>Comment</key>
+			<string>Verify MD5 matches 4.6.2.1019 on the postinstall script</string>
+			<key>Processor</key>
+			<string>io.github.hjuutilainen.SharedProcessors/ChecksumVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict/>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/root/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing</string>
+			</dict>
+			<key>Comment</key>
+			<string>Create a root for creating the installs array</string>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/root/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing/Assets.InDesignPlugin</string>
+				<key>overwrite</key>
+				<true/>
+				<key>source_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/cc2023/Assets.InDesignPlugin</string>
+			</dict>
+			<key>Comment</key>
+			<string>Copy the InDesign plugin to the fake destination to allow creation of an installs array</string>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/root</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing/Assets.InDesignPlugin</string>
+				</array>
+				<key>version_comparison_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Comment</key>
+			<string>Create an installs array item for Assets.InDesignPlugin</string>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Comment</key>
+			<string>Merge the installs array into the pkginfo</string>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/root/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing/Assets.InDesignPlugin/Resources/Info.plist</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--uninstall_script=%RECIPE_DIR%/Assets Scripts InDesign 2023/Fixed Scripts/Uninstall WoodWing Assets for InDesign</string>
+					<string>--postuninstall_script=%RECIPE_DIR%/Assets Scripts InDesign 2023/My Scripts/Forget InDesign Receipts 2023.sh</string>
+				</array>
+				<key>force_munkiimport</key>
+				<true/>
+				<key>pkg_path</key>
+				<string>%PKG%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Comment</key>
+			<string>Import the package into Munki</string>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/WoodWing/WoodwingStudioInDesignCC2023.munki.recipe
+++ b/WoodWing/WoodwingStudioInDesignCC2023.munki.recipe
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Packages Woodwing Studio for InDesign 2023 and imports it into Munki.
+
+NOTES:
+- This recipe depends on hjuutilainen's ChecksumVerifier.  Add this repos via:
+
+autopkg repo-add hjuutilainen-recipes
+
+- Specific pkgs are disabled via InstallerChoices depending on the product that's being installed.  Due to this, the packages are identical--thus force_munkiimport is set to true
+- This recipe does not download the Woodwing Studio disk image--feed the disk image into the recipe via the following format:
+
+autopkg run WoodwingStudioInDesignCC2023.munki.recipe -p /path/to/WoodWing_Studio_for_InDesign_and_InCopy_2023_v18.0.2_Build15.dmg</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.munki.WoodwingSmartConnectionInDesignCC2023</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>plugins/woodwing</string>
+		<key>NAME</key>
+		<string>WoodwingStudioInDesignCC2023</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>Comment</key>
+			<string>Choices installer_choice_1 (Woodwing Studio InDesign 2023), installer_choice_2 (Woodwing Studio InCopy 2023)</string>
+			<key>blocking_applications</key>
+			<array>
+				<string>Adobe InDesign 2023</string>
+			</array>
+			<key>catalogs</key>
+			<array>
+				<string>development-woodwing-WoodwingStudioInDesignCC2023</string>
+			</array>
+			<key>category</key>
+			<string>Plugins</string>
+			<key>description</key>
+			<string>Woodwing Studio plugins for InDesign 2023.</string>
+			<key>developer</key>
+			<string>Woodwing</string>
+			<key>display_name</key>
+			<string>Woodwing Studio InDesign 2023</string>
+			<key>installer_choices_xml</key>
+			<array>
+				<dict>
+					<key>attributeSetting</key>
+					<integer>1</integer>
+					<key>choiceAttribute</key>
+					<string>selected</string>
+					<key>choiceIdentifier</key>
+					<string>installer_choice_1</string>
+				</dict>
+			</array>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>requires</key>
+			<array>
+				<string>InDesignCC2023</string>
+			</array>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Comment</key>
+			<string>Not going to tackle downloading the software right now</string>
+			<key>Processor</key>
+			<string>PackageRequired</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>flat_pkg_path</key>
+				<string>%PKG%/WoodWing_Studio_for_InDesign_and_InCopy_2023_v*.pkg</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Comment</key>
+			<string>Unpack the original package</string>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>algorithm</key>
+				<string>MD5</string>
+				<key>checksum</key>
+				<string>88f44c5308414445efa5c6b25860a237</string>
+				<key>pathname</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2023.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2023</string>
+			</dict>
+			<key>Comment</key>
+			<string>Verify MD5 matches 17.0.0, build 15 on the uninstall script</string>
+			<key>Processor</key>
+			<string>io.github.hjuutilainen.SharedProcessors/ChecksumVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>algorithm</key>
+				<string>MD5</string>
+				<key>checksum</key>
+				<string>88f44c5308414445efa5c6b25860a237</string>
+				<key>pathname</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2023.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2023.sh</string>
+			</dict>
+			<key>Comment</key>
+			<string>Verify MD5 matches 17.0.0, build 15 on the uninstall script</string>
+			<key>Processor</key>
+			<string>io.github.hjuutilainen.SharedProcessors/ChecksumVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>algorithm</key>
+				<string>MD5</string>
+				<key>checksum</key>
+				<string>cf92122a72b1a60b6a97a9843efc7a1d</string>
+				<key>pathname</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/WWSTUDIOID2023.pkg/Scripts/postinstall</string>
+			</dict>
+			<key>Comment</key>
+			<string>Verify MD5 matches 17.0.0, build 15 on the postinstall script--since the postinstall script is what does all the heavy lifting it is imperative to ensure there have been no changes since the last time the postinstall was reviewed.  Any changes would trigger a (hand) review of the changes to determine whether the script's activities are impacted and whether the modified script requires an update.</string>
+			<key>Processor</key>
+			<string>io.github.hjuutilainen.SharedProcessors/ChecksumVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict/>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/payload_scenterprise/root/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing</string>
+			</dict>
+			<key>Comment</key>
+			<string>Create a root for the expanded scenterprise.pkg payload</string>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload_scenterprise/root/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing/SCEnterprise.InDesignPlugin</string>
+				<key>overwrite</key>
+				<true/>
+				<key>source_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Plug-ins/SCEnterprise.InDesignPlugin</string>
+			</dict>
+			<key>Comment</key>
+			<string>Copy SCEnterprise.InDesignPlugin into the destination</string>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/payload_scenterprise/root</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing/SCEnterprise.InDesignPlugin</string>
+				</array>
+				<key>version_comparison_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Comment</key>
+			<string>Create an installs array item for SCEnterprise.InDesignPlugin</string>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Comment</key>
+			<string>Merge the installs array into the pkginfo</string>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>"CFBundleShortVersionString" = "Studio v([\d\.]+)</string>
+				<key>result_output_var_name</key>
+				<string>discovered_version</string>
+				<key>url</key>
+				<string>file:////%RECIPE_CACHE_DIR%/payload_scenterprise/root/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing/SCEnterprise.InDesignPlugin/Versions/A/Resources/Resources/English.lproj/InfoPlist.strings</string>
+			</dict>
+			<key>Comment</key>
+			<string>Extract the version number</string>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>"CFBundleShortVersionString" = .* build (\d+)</string>
+				<key>result_output_var_name</key>
+				<string>build</string>
+				<key>url</key>
+				<string>file:////%RECIPE_CACHE_DIR%/payload_scenterprise/root/Applications/Adobe InDesign 2023/Plug-Ins/WoodWing/SCEnterprise.InDesignPlugin/Versions/A/Resources/Resources/English.lproj/InfoPlist.strings</string>
+			</dict>
+			<key>Comment</key>
+			<string>Extract the build number</string>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%discovered_version%.%build%</string>
+				</dict>
+			</dict>
+			<key>Comment</key>
+			<string>Add Munki pkginfo, set "version" to version plus build as the Munki</string>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--uninstall_script=%RECIPE_DIR%/Reference Scripts 2023/Fixed Scripts/wwuninstall_indesign2023_fixed.sh</string>
+					<string>--postuninstall_script=%RECIPE_DIR%/Reference Scripts 2023/My Scripts/Forget InDesign Receipts 2023.sh</string>
+				</array>
+				<key>force_munkiimport</key>
+				<true/>
+				<key>pkg_path</key>
+				<string>%PKG%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Comment</key>
+			<string>Import the package into Munki</string>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Updated recipes for CC 2023 offerings.

Since the 2022 recipe was last evaluated against 4.6.2 the installer choices are the same, but this recipe has been updated to use the CC 2023 choice.

```installer -pkg /Users/eholtam/Downloads/WoodWing\ Assets\ for\ InDesign.pkg -tgt / -showChoicesXML 
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<array>
	<dict>
		<key>childItems</key>
		<array>
			<dict>
				<key>childItems</key>
				<array/>
				<key>choiceDescription</key>
				<string>Install WoodWing Assets for InDesign 2023</string>
				<key>choiceIdentifier</key>
				<string>installer_choice_1</string>
				<key>choiceIsEnabled</key>
				<true/>
				<key>choiceIsSelected</key>
				<integer>0</integer>
				<key>choiceIsVisible</key>
				<true/>
				<key>choiceSizeInKilobytes</key>
				<integer>4500</integer>
				<key>choiceTitle</key>
				<string>Assets for InDesign 2023</string>
				<key>pathsOfActivePackagesInChoice</key>
				<array>
					<string>file://localhost/Users/eholtam/Downloads/WoodWing%20Assets%20for%20InDesign.pkg#ASSETSID2023.pkg</string>
				</array>
			</dict>
```

A sample run of the updated recipe was clean and imported `AssetsInDesignCC2023Plugin` without issue.