### PR TITLE
Add Proper Fractions Lite recipes for CC 2023

### DIFF
--- a/DanRodney/ProperFractionLiteHVScaleInDesignCC2023.munki.recipe
+++ b/DanRodney/ProperFractionLiteHVScaleInDesignCC2023.munki.recipe
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads latest Proper Fraction Lite disk image, packages the Proper Fraction Lite H+V Scale script for InDesign CC 2023, and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.munki.ProperFractionLiteHVScaleInDesignCC2023</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>plugins/danrodney</string>
+		<key>NAME</key>
+		<string>ProperFractionLiteHVScaleInDesignCC2023</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>development-danrodney-ProperFractionLiteHVScaleInDesignCC2023</string>
+			</array>
+			<key>category</key>
+			<string>Productivity</string>
+			<key>description</key>
+			<string>The most complete solution to make fractions in Adobe InDesign and InCopy</string>
+			<key>developer</key>
+			<string>Dan Rodney</string>
+			<key>display_name</key>
+			<string>Proper Fraction Lite H+V Scale</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>requires</key>
+			<array>
+				<string>InDesignCC2023</string>
+			</array>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.foigus.pkg.ProperFractionLiteHVScaleInDesignCC2023</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/DanRodney/ProperFractionLiteHVScaleInDesignCC2023.pkg.recipe
+++ b/DanRodney/ProperFractionLiteHVScaleInDesignCC2023.pkg.recipe
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads latest Proper Fraction Lite disk image and packages the Proper Fraction Lite H+V Scale script for InDesign 2023.</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.pkg.ProperFractionLiteHVScaleInDesignCC2023</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>ProperFractionLiteHVScaleInDesignCC2023</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.foigus.download.ProperFractionLite</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unarchive</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/unarchive/Proper Fraction Lite*/Proper Fraction Lite * H+V Scale DanRodney.js</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+					<key>Applications/Adobe InDesign 2023</key>
+					<string>0775</string>
+					<key>Applications/Adobe InDesign 2023/Scripts</key>
+					<string>0775</string>
+					<key>Applications/Adobe InDesign 2023/Scripts/Scripts Panel</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/Adobe InDesign 2023/Scripts/Scripts Panel</string>
+				<key>source_path</key>
+				<string>%found_filename%</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_request</key>
+				<dict>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>group</key>
+							<string>wheel</string>
+							<key>path</key>
+							<string>Applications</string>
+							<key>user</key>
+							<string>root</string>
+						</dict>
+					</array>
+					<key>id</key>
+					<string>com.danrodney.ProperFractionLiteHVScaleInDesignCC2023.pkg</string>
+					<key>pkgname</key>
+					<string>ProperFractionLiteHVScaleInDesignCC2023-%version%</string>
+					<key>pkgroot</key>
+					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+					<key>pkgtype</key>
+					<string>flat</string>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
No significant changes besides the path to the CC 2023 application where the script installs to.