### PR TITLE
Update CaptureOne.download.recipe

### DIFF
--- a/PhaseOne/CaptureOne.download.recipe
+++ b/PhaseOne/CaptureOne.download.recipe
@@ -18,7 +18,7 @@ NOTES:
 		<key>CODESIGNATUREVERIFIERREQUIREMENT</key>
 		<string>anchor apple generic and identifier "com.captureone.captureone16" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5WTDB5F65L")</string>
 		<key>DOWNLOADURLUUID</key>
-		<string>e569c884-1ffe-4e8a-9514-437beec374e7</string>
+		<string>4d402047e08d5f50352135d7ce4184c39c26ea84</string>
 		<key>LANGUAGE</key>
 		<string>International</string>
 		<key>MARKETING_VERSION</key>
@@ -49,7 +49,7 @@ NOTES:
 				<key>filename</key>
 				<string>CaptureOne.dmg</string>
 				<key>url</key>
-				<string>https://downloads.phaseone.com/%DOWNLOADURLUUID%/%LANGUAGE%/CaptureOne%MARKETING_VERSION%.Mac.%truncated_version%.dmg</string>
+				<string>https://downloads.phaseone.com/%DOWNLOADURLUUID%/CaptureOne%MARKETING_VERSION%.Mac.%truncated_version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hi, @foigus 

The CaptureOne Download recipe is currently failing with
```
Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://downloads.phaseone.com/4d402047e08d5f50352135d7ce4184c39c26ea84/International/CaptureOne23.Mac.16.2.5.9.dmg', '--fail', '--output', '/Users/sadmin/Library/AutoPkg/Cache/local.definition.CaptureOne23/downloads/tmp7l1l0rt9']' returned non-zero exit status 22.
```
This PR updated the `DOWNLOADURLUUID` and removes the language from the download url

Output from a successful -v run

```
autopkg run -vv /Users/paul.cossey/Documents/GitHub/AutoPkg\ Repos/foigus-recipes/PhaseOne/CaptureOne.download.recipe 
Processing /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/foigus-recipes/PhaseOne/CaptureOne.download.recipe...
WARNING: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/foigus-recipes/PhaseOne/CaptureOne.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<AvailableVersion>(16(.[0-9]+(\\.[0-9]+)+))</AvailableVersion',
           'result_output_var_name': 'truncated_version',
           'url': 'https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=8.0'}}
URLTextSearcher: Found matching text (truncated_version): 16.2.5.9
{'Output': {'truncated_version': '16.2.5.9'}}
URLDownloader
{'Input': {'filename': 'CaptureOne.dmg',
           'url': 'https://downloads.phaseone.com/4d402047e08d5f50352135d7ce4184c39c26ea84/CaptureOne23.Mac.16.2.5.9.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 19 Sep 2023 18:51:23 GMT
URLDownloader: Storing new ETag header: "5738ec16c78736f09962f37c4dfd2c45-141"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg
{'Output': {'download_changed': True,
            'etag': '"5738ec16c78736f09962f37c4dfd2c45-141"',
            'last_modified': 'Tue, 19 Sep 2023 18:51:23 GMT',
            'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg/Capture '
                         'One 23.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.captureone.captureone16" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5WTDB5F65L")'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.FzMEEA/Capture One 23.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.FzMEEA/Capture One 23.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.FzMEEA/Capture One 23.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/receipts/CaptureOne.download-receipt-20230921-160155.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg 
```