### PR TITLE
Update CaptureOne Download Recipe

### DIFF
--- a/PhaseOne/CaptureOne.download.recipe
+++ b/PhaseOne/CaptureOne.download.recipe
@@ -8,7 +8,9 @@
 NOTES:
 
 - Due to Phase One's decision to go with different versions for the software itself and marketing (e.g. Capture One version 13 is marketed as version 20), this recipe also has a MARKETING_VERSION variable to account for the discrepancy.
-- Major version upgrades of Capture One perpetual licenses are generally paid upgrades, however Phase One's update URL doesn't stop at major version boundaries (e.g. the update URL for Capture One 7 offers a download of Capture One 9) and new major versions of Capture One are paid updates.  In an attempt to avoid accidentally downloading (and subsequently importing) Capture One updates that require a paid update, we restrict to an ACTUAL_VERSION and a corresponding MARKETING_VERSION.  When Phase One releases a new major version, this recipe will break until ACTUAL_VERSION and MARKETING_VERSION are updated (either via override or by updating this recipe).</string>
+- Major version upgrades of Capture One perpetual licenses are generally paid upgrades, however Phase One's update URL doesn't stop at major version boundaries (e.g. the update URL for Capture One 7 offers a download of Capture One 9) and new major versions of Capture One are paid updates.	In an attempt to avoid accidentally downloading (and subsequently importing) Capture One updates that require a paid update, we restrict to an ACTUAL_VERSION and a corresponding MARKETING_VERSION.  When Phase One releases a new major version, this recipe will break until ACTUAL_VERSION and MARKETING_VERSION are updated (either via override or by updating this recipe).
+
+- As of October 2023 the MARKETING_VERSION seems to have been dropped. Please remove from overrides to grab the latest version.</string>
 	<key>Identifier</key>
 	<string>com.github.foigus.download.CaptureOne</string>
 	<key>Input</key>
@@ -18,11 +20,11 @@ NOTES:
 		<key>CODESIGNATUREVERIFIERREQUIREMENT</key>
 		<string>anchor apple generic and identifier "com.captureone.captureone16" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5WTDB5F65L")</string>
 		<key>DOWNLOADURLUUID</key>
-		<string>4d402047e08d5f50352135d7ce4184c39c26ea84</string>
+		<string>ff446fcfadc80ea99d12a24269e47483a179e322</string>
 		<key>LANGUAGE</key>
 		<string>International</string>
 		<key>MARKETING_VERSION</key>
-		<string>23</string>
+		<string></string>
 		<key>NAME</key>
 		<string>CaptureOne</string>
 	</dict>
@@ -49,7 +51,7 @@ NOTES:
 				<key>filename</key>
 				<string>CaptureOne.dmg</string>
 				<key>url</key>
-				<string>https://downloads.phaseone.com/%DOWNLOADURLUUID%/CaptureOne%MARKETING_VERSION%.Mac.%truncated_version%.dmg</string>
+				<string>https://downloads.captureone.pro/%DOWNLOADURLUUID%/CaptureOne%MARKETING_VERSION%.Mac.%truncated_version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -61,8 +63,17 @@ NOTES:
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pattern</key>
+				<string>%pathname%/*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Capture One %MARKETING_VERSION%.app</string>
+				<string>%pathname%/%found_basename%</string>
 				<key>requirement</key>
 				<string>%CODESIGNATUREVERIFIERREQUIREMENT%</string>
 			</dict>


### PR DESCRIPTION
Hi, @foigus 

CaptureOne is currently failing with 
```
Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://downloads.phaseone.com/4d402047e08d5f50352135d7ce4184c39c26ea84/CaptureOne23.Mac.16.3.0.76.dmg', '--fail', '--output', 'File Path']' returned non-zero exit status 22.
```

This PR 
- Updates the` DOWNLOADURLUUID`
- Blanks out the `MARKETING_VERSION` variable as this seems to have been dropped by the vendor
- Adds in `FileFinder` to grab the App name for `CodeSignatureVerifier`
- Updated Description to inform about the change to `MARKETING_VERSION` for the latest release. 

Output from a successful verbose run

```
autopkg run -vv CaptureOne.download.recipe
**load_recipe time: 0.0003711669996846467
Processing CaptureOne.download.recipe...
WARNING: CaptureOne.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<AvailableVersion>(16(.[0-9]+(\\.[0-9]+)+))</AvailableVersion',
           'result_output_var_name': 'truncated_version',
           'url': 'https://cormws.phaseone.com/corm.asmx/GetNewSoftwareVersion?Platform=Mac&Version=8.0'}}
URLTextSearcher: Found matching text (truncated_version): 16.3.0.76
{'Output': {'truncated_version': '16.3.0.76'}}
URLDownloader
{'Input': {'filename': 'CaptureOne.dmg',
           'url': 'https://downloads.captureone.pro/ff446fcfadc80ea99d12a24269e47483a179e322/CaptureOne.Mac.16.3.0.76.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 25 Oct 2023 08:02:35 GMT
URLDownloader: Storing new ETag header: "a0acfc4aa350eed16ceb9adc814b0347-190"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg
{'Output': {'download_changed': True,
            'etag': '"a0acfc4aa350eed16ceb9adc814b0347-190"',
            'last_modified': 'Wed, 25 Oct 2023 08:02:35 GMT',
            'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
FileFinder
{'Input': {'pattern': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg/*.app'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg
FileFinder: Found file match: '/private/tmp/dmg.XiuXsz/Capture One.app' from globbed '/private/tmp/dmg.XiuXsz/*.app'
FileFinder: DMG-relative file match: 'Capture One.app'
FileFinder: Basename match: 'Capture One.app'
{'Output': {'dmg_found_filename': 'Capture One.app',
            'found_basename': 'Capture One.app',
            'found_filename': '/private/tmp/dmg.XiuXsz/Capture One.app'}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg/Capture '
                         'One.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.captureone.captureone16" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5WTDB5F65L")'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.r39uwr/Capture One.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.r39uwr/Capture One.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.r39uwr/Capture One.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/receipts/CaptureOne.download-receipt-20231031-103544.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.download.CaptureOne/downloads/CaptureOne.dmg 
```
