### PR TITLE
Added Inspire Designer 16 Plugin for InDesign 2023

### DIFF
--- a/GMCSoftware/InspireDesigner16ExportCC2023.download.recipe
+++ b/GMCSoftware/InspireDesigner16ExportCC2023.download.recipe
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Verifies the Inspire Designer 16 Export Plugins package.
+
+NOTE:
+- This recipe does not download the Inspire Designer 16 Export plugin disk image--feed the disk image into the recipe via the following format:
+
+autopkg run InspireDesigner16ExportCC2023.download -p /path/to/Adobe-InDesign-2023-Plugin-R16-GA.pkg</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.download.InspireDesigner16ExportCC2023</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>InspireDesigner16ExportCC2023</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Comment</key>
+			<string>Not going to tackle downloading the software right now</string>
+			<key>Processor</key>
+			<string>PackageRequired</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Quadient s.r.o. (RK2GK9U5VX)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%PKG%/*.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/GMCSoftware/InspireDesigner16ExportCC2023.munki.recipe
+++ b/GMCSoftware/InspireDesigner16ExportCC2023.munki.recipe
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Packages Inspire Designer 16 Export plugin for InDesign CC 2023 and imports it into Munki
+
+NOTES:
+- This recipe depends on hjuutilainen's ChecksumVerifier.  Add hjuutilainen's repo via:
+
+autopkg repo-add hjuutilainen-recipes
+
+- This recipe points to the default installation location of InDesign CC 2023.  Adjust the path as needed.
+- This recipe does not download the Inspire Designer 16 Export plugin disk image--feed the disk image into the recipe via the following format:
+
+autopkg run InspireDesigner16ExportCC2023.munki -p /path/to/InstallerPackage-AdobeInDesign23Plugin-16.3.0.0-FMAP-Mac64.dmg</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.munki.InspireDesigner16ExportCC2023</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>plugins/gmcsoftware</string>
+		<key>NAME</key>
+		<string>InspireDesigner16ExportCC2023</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>blocking_applications</key>
+			<array>
+				<string>Adobe InDesign 2023</string>
+			</array>
+			<key>catalogs</key>
+			<array>
+				<string>development-gmcsoftware-InspireDesigner16ExportCC2023</string>
+			</array>
+			<key>category</key>
+			<string>Plugins</string>
+			<key>description</key>
+			<string>This plugin for Adobe InDesign CC exports InDesign documents into XML and/or WFD files that can be imported into Inspire Designer.</string>
+			<key>developer</key>
+			<string>GMC Software</string>
+			<key>display_name</key>
+			<string>Inspire Designer 16 Export Plugin CC 2023</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>requires</key>
+			<array>
+				<string>InDesignCC2023</string>
+			</array>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+			<key>uninstall_method</key>
+			<string>uninstall_script</string>
+			<key>uninstall_script</key>
+			<string>#!/bin/bash
+
+rm -rf "/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.InDesignPlugin"
+rm -rf "/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.ini"
+
+#The remaining items might be used with other GMC Software products.  Listing them
+#here but commenting them out.
+#
+#rm -rf /Library/Application\ Support/GMC/Fonts
+#rm -rf /Library/Application\ Support/GMC/Inspire Designer
+#rm -rf /private/etc/Chimenix/</string>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.foigus.pkg.InspireDesigner16ExportCC2023</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/expand_munki_recipe</string>
+				<key>flat_pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/flatten/InspireDesigner16ExportCC2023-%version%.pkg</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Comment</key>
+			<string>Expand the package</string>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/expand_munki_recipe/Adobe_InDesign_2023_Plugin_*.pkg</string>
+			</dict>
+			<key>Comment</key>
+			<string>Find the name of the plugin package.</string>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack_munki_recipe</string>
+				<key>pkg_payload_path</key>
+				<string>%found_filename%/Payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Comment</key>
+			<string></string>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict/>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/Adobe InDesign 2023/Plug-Ins</string>
+			</dict>
+			<key>Comment</key>
+			<string>Create a root for the plugin payload</string>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/Adobe InDesign 2023/Plug-Ins</string>
+				<key>overwrite</key>
+				<true/>
+				<key>source_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack_munki_recipe/tmp</string>
+			</dict>
+			<key>Comment</key>
+			<string>Copy over the plug for an installs item</string>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.InDesignPlugin/Versions/A/Frameworks/PrintNetTExporter.framework/Versions/A/Resources/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.InDesignPlugin/Versions/A/Frameworks/PrintNetTExporter.framework</string>
+				</array>
+			</dict>
+			<key>Comment</key>
+			<string>Create an installs array item for InspireDesignerIn.InDesignPlugin</string>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Comment</key>
+			<string>Merge the installs array into the pkginfo</string>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/flatten/InspireDesigner16ExportCC2023-%version%.pkg</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Comment</key>
+			<string>Import the package into Munki</string>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/GMCSoftware/InspireDesigner16ExportCC2023.pkg.recipe
+++ b/GMCSoftware/InspireDesigner16ExportCC2023.pkg.recipe
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Packages Inspire Designer 16 Export plugin for InDesign CC 2023.
+
+NOTES:
+- This recipe depends on hjuutilainen's ChecksumVerifier.  Add hjuutilainen's repo via:
+
+autopkg repo-add hjuutilainen-recipes
+
+- This recipe points to the default installation location of InDesign CC 2023.  Adjust the path as needed.
+- This recipe does not download the Inspire Designer 16 Export plugin disk image--feed the disk image into the recipe via the following format:
+
+autopkg run InspireDesigner16ExportCC2023.pkg -p /path/to/InstallerPackage-AdobeInDesign2023Plugin-16.3.0.0-FMAP-Mac64.dmg</string>
+	<key>Identifier</key>
+	<string>com.github.foigus.pkg.InspireDesigner16ExportCC2023</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>InspireDesigner16ExportCC2023</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.5.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.foigus.download.InspireDesigner16ExportCC2023</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/expand_pkg_recipe</string>
+				<key>flat_pkg_path</key>
+				<string>%PKG%/*.pkg</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Comment</key>
+			<string>Expand the package</string>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/expand_pkg_recipe/Adobe_InDesign_2023_Plugin_*.pkg</string>
+			</dict>
+			<key>Comment</key>
+			<string>Find the name of the plugin package.</string>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>algorithm</key>
+				<string>MD5</string>
+				<key>checksum</key>
+				<string>c154c8a915963f28649c1c39870750e0</string>
+				<key>pathname</key>
+				<string>%found_filename%/Scripts/postinstall</string>
+			</dict>
+			<key>Comment</key>
+			<string>Verify MD5 matches 15.3.0 "postinstall" script</string>
+			<key>Processor</key>
+			<string>io.github.hjuutilainen.SharedProcessors/ChecksumVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%found_filename%/Scripts/postinstall</string>
+				</array>
+			</dict>
+			<key>Comments</key>
+			<string>Remove this copy of "postinstall" script</string>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>file_content</key>
+				<string>#!/bin/zsh
+
+scriptDir="$(dirname "$0")"
+
+. "$scriptDir/common.sh"
+. "$scriptDir/installer.data"
+
+src="/tmp/InspireDesignerIn.InDesignPlugin"
+dest="/tmp/com.quadient.InDesignPlugin.destination"
+licenseCFG="/tmp/com.quadient.InDesignPlugin.config"
+licenseLIC="/tmp/com.quadient.PNetT.lic"
+echo -n "/Applications/Adobe InDesign 2023" &gt; /tmp/com.quadient.InDesignPlugin.destination
+
+if [ -f "$dest" ]; then
+	pluginDest="$(cat "$dest")/Plug-Ins"
+	iniFileDest="$pluginDest/InspireDesignerIn.ini"
+	if [ -d "$pluginDest" ]; then
+		ditto --rsrc "$src" "$pluginDest/InspireDesignerIn.InDesignPlugin" &amp;&amp; rm -f "$dest" &amp;&amp; rm -rf "$src"
+		echo "LINESPACE=EXACT,GADIALOG=YES,OUTPUT=FLOWAREA"&gt;"$iniFileDest" &amp;&amp; chmod 777 "$iniFileDest"
+		if [ -f "$licenseCFG" ]; then
+			cp -f "$licenseCFG" "$pluginDest/PrintNetTExporter.config" &amp;&amp; rm -f "$licenseCFG"
+		fi
+		if [ -f "$licenseLIC" ]; then
+			licFilePath="$(cat "$licenseLIC")"
+			licFileTarget="$pluginDest/$(basename "$licFilePath")"
+			cp -f "$licFilePath" "$licFileTarget" &amp;&amp; chmod 644 "$licFileTarget" &amp;&amp; rm -f "$licenseLIC"
+		fi
+	fi
+fi
+
+# Cleanup temporary folder dirty from previous versions
+rm -rf "$HOME/Library/Application Support/Quadient/InspireExportInd"
+
+ForgetPackageWithDelay 10 "$INDD_PLUGIN_IDENTIFIER" &amp;
+
+exit 0</string>
+				<key>file_mode</key>
+				<string>0755</string>
+				<key>file_path</key>
+				<string>%found_filename%/Scripts/postinstall</string>
+			</dict>
+			<key>Comment</key>
+			<string>Write a fixed "postinstall" with an InDesign CC 2023-specific version, note this is the same script as postinstall_fixed in this repo</string>
+			<key>Processor</key>
+			<string>FileCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack_pkg_recipe</string>
+				<key>pkg_payload_path</key>
+				<string>%found_filename%/Payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Comment</key>
+			<string></string>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack_pkg_recipe/tmp/InspireDesignerIn.InDesignPlugin/Versions/A/Frameworks/PrintNetTExporter.framework/Versions/A/Resources/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict/>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/flatten</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_pkg</key>
+				<string>%RECIPE_CACHE_DIR%/flatten/InspireDesigner16ExportCC2023-%version%.pkg</string>
+				<key>source_flatpkg_dir</key>
+				<string>%RECIPE_CACHE_DIR%/expand_pkg_recipe</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgPacker</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This adds recipes for Inspire Designer 16 for InDesign CC 2023.
Validated the code on a live Munki repo and imported properly.
