### PR TITLE
Updated target path for installs array item.

### DIFF
--- a/GMCSoftware/InspireDesigner16ExportCC2023.munki.recipe
+++ b/GMCSoftware/InspireDesigner16ExportCC2023.munki.recipe
@@ -145,7 +145,7 @@ rm -rf "/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.ini"
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.InDesignPlugin/Versions/A/Frameworks/PrintNetTExporter.framework/Versions/A/Resources/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.InDesignPlugin/Resources/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>
@@ -171,7 +171,7 @@ rm -rf "/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.ini"
 				<string>%RECIPE_CACHE_DIR%/pkgroot/</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.InDesignPlugin/Versions/A/Frameworks/PrintNetTExporter.framework</string>
+					<string>/Applications/Adobe InDesign 2023/Plug-Ins/InspireDesignerIn.InDesignPlugin</string>
 				</array>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner16ExportCC2023.pkg.recipe
+++ b/GMCSoftware/InspireDesigner16ExportCC2023.pkg.recipe
@@ -150,7 +150,7 @@ exit 0</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack_pkg_recipe/tmp/InspireDesignerIn.InDesignPlugin/Versions/A/Frameworks/PrintNetTExporter.framework/Versions/A/Resources/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/unpack_pkg_recipe/tmp/InspireDesignerIn.InDesignPlugin/Resources/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Updated the target path for the installs array to the plugin version itself, not an obscure PrintNeTExporter path.