### PR TITLE
Update SpectraViewII download recipe

### DIFF
--- a/NEC/SpectraViewII.download.recipe
+++ b/NEC/SpectraViewII.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https:\/\/update\.sharpnecdisplays\.us\/spectraview\/NEC_SpectraView_MacOS_v[\d\.]+_multilanguage\.dmg</string>
+				<string>//update\.sharpnecdisplays\.us/spectraviewii/[A-Za-z_]+_v[\d.]+_multilanguage\.dmg</string>
 				<key>url</key>
 				<string>https://www.sharpnecdisplays.us/support-and-services/spectraviewii/4</string>
 			</dict>
@@ -32,7 +32,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>%match%</string>
+				<string>https:%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
URLTextSearcher regex changed to reflect that filename of disk image is now all lower case (but could change back on a whim, so regex now allows for mixed and lower case) and that the href links are now relative (no `https:`), so URLDownloader has `https:` added manually.