### PR TITLE
Update ColorNavigator 7 with new postinstall

### DIFF
--- a/EIZO/ColorNavigator7.pkg.recipe
+++ b/EIZO/ColorNavigator7.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest ColorNavigator 7 installer and modifies a postinstall to no longer open the ColorNavigator 7 window following installation. 
+	<string>Downloads the latest ColorNavigator 7 installer and modifies a postinstall to no longer open the ColorNavigator 7 window following installation.
 
 NOTES:
 - POSTINSTALL_SCRIPT_PATH must be set to reflect the location of the "postinstall" script--it can point back to the postinstall in the directory of the original recipe, but due to overrides it must be a piece of override-able INPUT
@@ -46,7 +46,7 @@ autopkg repo-add jessepeterson-recipes</string>
 				<key>algorithm</key>
 				<string>MD5</string>
 				<key>checksum</key>
-				<string>66840d489f66a5e9c0986723b2b09dfc</string>
+				<string>0097083918f66dc681dcb9331f863140</string>
 				<key>pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/ColorNavigator_7.pkg/Scripts/postinstall</string>
 			</dict>

--- a/EIZO/Reference Scripts ColorNavigator7/Fixed Script/postinstall
+++ b/EIZO/Reference Scripts ColorNavigator7/Fixed Script/postinstall
@@ -114,9 +114,19 @@ if [ -e "/Applications/CNNetAgent.app" ]; then
 	wait
 fi
 
+#-------------------------------------------------------------------------------
 # Create initSetting files
+#-------------------------------------------------------------------------------
+
+# Create check_update file
 if [ -e "${INST_FLAG_DIR}/checks_update" ]; then
 	cat /dev/null > "${INIT_SETTING_DIR}/checks_update"
+fi
+
+# When silent install is executed, create check_update file and silent_install file
+if [ ${COMMAND_LINE_INSTALL} == '1' ]; then
+	cat /dev/null > "${INIT_SETTING_DIR}/checks_update"
+	cat /dev/null > "${INIT_SETTING_DIR}/is_silent_install"
 fi
 
 #-------------------------------------------------------------------------------
@@ -124,7 +134,12 @@ fi
 #-------------------------------------------------------------------------------
 
 # Preferences
-cp "${PKG_DIR}/preferences.json" "${INIT_SETTING_DIR}/"
+PREF_FILE="preferences.json"
+if [ -e "${PKG_DIR}/${PREF_FILE}" ]; then
+	OUT_FILE_PATH="${INIT_SETTING_DIR}/${PREF_FILE}"
+	cp "${PKG_DIR}/${PREF_FILE}" "${OUT_FILE_PATH}"
+	chmod 666 "${OUT_FILE_PATH}"
+fi
 
 # Language packs
 mkdir "${LANG_PACK_DIR}" >& /dev/null
@@ -219,10 +234,9 @@ fi
 chmod -R 777 "${LOCK_FILE_DIR}"
 
 # Launch Application
-##Don't open the ColorNavigator window, it causes the installation to fail
-##su "${USER}" -c "open /Applications/ColorNavigator\ 7.app"
-##
-### Ignore error at app launch
-##if [ $? -ne 0 ]; then
+## su "${USER}" -c "open /Applications/ColorNavigator\ 7.app"
+
+# Ignore error at app launch
+## if [ $? -ne 0 ]; then
 ##	exit 0
-##fi
+## fi

--- a/EIZO/Reference Scripts ColorNavigator7/Original EIZO Script/postinstall
+++ b/EIZO/Reference Scripts ColorNavigator7/Original EIZO Script/postinstall
@@ -114,9 +114,19 @@ if [ -e "/Applications/CNNetAgent.app" ]; then
 	wait
 fi
 
+#-------------------------------------------------------------------------------
 # Create initSetting files
+#-------------------------------------------------------------------------------
+
+# Create check_update file
 if [ -e "${INST_FLAG_DIR}/checks_update" ]; then
 	cat /dev/null > "${INIT_SETTING_DIR}/checks_update"
+fi
+
+# When silent install is executed, create check_update file and silent_install file
+if [ ${COMMAND_LINE_INSTALL} == '1' ]; then
+	cat /dev/null > "${INIT_SETTING_DIR}/checks_update"
+	cat /dev/null > "${INIT_SETTING_DIR}/is_silent_install"
 fi
 
 #-------------------------------------------------------------------------------
@@ -124,7 +134,12 @@ fi
 #-------------------------------------------------------------------------------
 
 # Preferences
-cp "${PKG_DIR}/preferences.json" "${INIT_SETTING_DIR}/"
+PREF_FILE="preferences.json"
+if [ -e "${PKG_DIR}/${PREF_FILE}" ]; then
+	OUT_FILE_PATH="${INIT_SETTING_DIR}/${PREF_FILE}"
+	cp "${PKG_DIR}/${PREF_FILE}" "${OUT_FILE_PATH}"
+	chmod 666 "${OUT_FILE_PATH}"
+fi
 
 # Language packs
 mkdir "${LANG_PACK_DIR}" >& /dev/null


### PR DESCRIPTION
Hi, @foigus 

This PR updates ColorNavigator 7 with the vendors new postinstall script. 

Output from a -vv run
```
autopkg run -vv ColorNavigator7.munki.recipe                                                                                                      
Looking for com.github.foigus.pkg.ColorNavigator7...
Did not find com.github.foigus.pkg.ColorNavigator7 in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.foigus.pkg.ColorNavigator7...
Found com.github.foigus.pkg.ColorNavigator7 in recipe map
Looking for com.github.foigus.download.ColorNavigator7...
Found com.github.foigus.download.ColorNavigator7 in recipe map
**load_recipe time: 0.007911874999990687
Processing ColorNavigator7.munki.recipe...
WARNING: ColorNavigator7.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https:\\/\\/www\\.eizoglobal\\.com/support/db/files/software/software/graphics/colornavigator7/ColorNavigator[\\d]+.pkg',
           'url': 'https://www.eizo.co.jp/update/cn7-update-v2-global.json'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://www.eizoglobal.com/support/db/files/software/software/graphics/colornavigator7/ColorNavigator720.pkg
{'Output': {'match': 'https://www.eizoglobal.com/support/db/files/software/software/graphics/colornavigator7/ColorNavigator720.pkg'}}
URLDownloader
{'Input': {'filename': 'ColorNavigator7.pkg',
           'url': 'https://www.eizoglobal.com/support/db/files/software/software/graphics/colornavigator7/ColorNavigator720.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/downloads/ColorNavigator7.pkg
{'Output': {'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/downloads/ColorNavigator7.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: EIZO '
                                        'Corporation (FWVNE2DRY7)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/downloads/ColorNavigator7.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "ColorNavigator7.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-03-15 05:11:21 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: EIZO Corporation (FWVNE2DRY7)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            69 45 7E 2C 4A 05 94 13 0E 5B CF 1B 0E EE E4 17 50 35 9C 14 6E D7 
CodeSignatureVerifier:            40 9B F0 B4 D1 82 5C 3C AA 64
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack',
           'flat_pkg_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/downloads/ColorNavigator7.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/downloads/ColorNavigator7.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack
{'Output': {}}
io.github.hjuutilainen.SharedProcessors/ChecksumVerifier
{'Input': {'algorithm': 'MD5',
           'checksum': '0097083918f66dc681dcb9331f863140',
           'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Scripts/postinstall'}}
ChecksumVerifier: Calculating MD5 checksum for /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Scripts/postinstall
ChecksumVerifier: Calculated checksum: 0097083918f66dc681dcb9331f863140
ChecksumVerifier: Expected checksum:   0097083918f66dc681dcb9331f863140
ChecksumVerifier: Calculated checksum matches the expected checksum.
{'Output': {}}
PathDeleter
{'Input': {'path_list': ['/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Scripts/postinstall']}}
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Scripts/postinstall
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Scripts/postinstall',
           'source_path': '/Users/paul.cossey/Documents/GitHub/AutoPkg '
                          'Repos/foigus-recipes/EIZO/Reference Scripts '
                          'ColorNavigator7/Fixed Script/postinstall'}}
Copier: Parsed dmg results: dmg_path: /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/foigus-recipes/EIZO/Reference Scripts ColorNavigator7/Fixed Script/postinstall, dmg: , dmg_source_path: 
Copier: Copied /Users/paul.cossey/Documents/GitHub/AutoPkg Repos/foigus-recipes/EIZO/Reference Scripts ColorNavigator7/Fixed Script/postinstall to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Scripts/postinstall
{'Output': {}}
com.github.jessepeterson.munki.UniversalTypeClient6/ModeChanger
{'Input': {'filename': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Scripts/postinstall',
           'mode': '755'}}
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root'}}
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root',
           'pkg_payload_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root/Applications/ColorNavigator '
                               '7.app/Contents/Info.plist'}}
Versioner: No value supplied for plist_version_key, setting default value of: CFBundleShortVersionString
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 7.2.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root/Applications/ColorNavigator 7.app/Contents/Info.plist
{'Output': {'version': '7.2.0'}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/repack'}}
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/repack
{'Output': {}}
FlatPkgPacker
{'Input': {'destination_pkg': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/repack/ColorNavigator7-7.2.0.pkg',
           'source_flatpkg_dir': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack'}}
FlatPkgPacker: Flattened /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/repack/ColorNavigator7-7.2.0.pkg
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack',
           'flat_pkg_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/repack/ColorNavigator7-7.2.0.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/repack/ColorNavigator7-7.2.0.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root'}}
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root',
           'pkg_payload_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack/ColorNavigator_7.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root',
           'installs_item_paths': ['/Applications/ColorNavigator 7.app']}}
MunkiInstallsItemsCreator: Created installs item for /Applications/ColorNavigator 7.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7',
                                                 'CFBundleName': 'ColorNavigator '
                                                                 '7',
                                                 'CFBundleShortVersionString': '7.2.0',
                                                 'CFBundleVersion': '0',
                                                 'minosversion': '10.14',
                                                 'path': '/Applications/ColorNavigator '
                                                         '7.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7',
                                                'CFBundleName': 'ColorNavigator '
                                                                '7',
                                                'CFBundleShortVersionString': '7.2.0',
                                                'CFBundleVersion': '0',
                                                'minosversion': '10.14',
                                                'path': '/Applications/ColorNavigator '
                                                        '7.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'RestartAction': 'RequireLogout',
                       'catalogs': ['development-eizo-ColorNavigator7'],
                       'category': 'Utility',
                       'description': 'Complete color management software '
                                      'solution for reliable calibration and '
                                      'quality control management of ColorEdge '
                                      'monitors.',
                       'developer': 'EIZO',
                       'display_name': 'ColorNavigator 7',
                       'minimum_os_version': '10.10',
                       'name': 'ColorNavigator7',
                       'unattended_install': False,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/sh\n'
                                           '#Per the "Installation Guide"\n'
                                           '#https://www.eizoglobal.com/support/db/files/manuals/03V27670C1/UM-03V27670C1-EN.pdf\n'
                                           'rm -rf '
                                           '"/Applications/ColorNavigator '
                                           '7.app"\n'
                                           '\t\t\t\n'
                                           'pkgutil --forget '
                                           'com.eizo.pkg.ColorNavigator7',
                       'uninstallable': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7', 'CFBundleName': 'ColorNavigator 7', 'CFBundleShortVersionString': '7.2.0', 'CFBundleVersion': '0', 'minosversion': '10.14', 'path': '/Applications/ColorNavigator 7.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'RestartAction': 'RequireLogout',
                        'catalogs': ['development-eizo-ColorNavigator7'],
                        'category': 'Utility',
                        'description': 'Complete color management software '
                                       'solution for reliable calibration and '
                                       'quality control management of '
                                       'ColorEdge monitors.',
                        'developer': 'EIZO',
                        'display_name': 'ColorNavigator 7',
                        'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7',
                                      'CFBundleName': 'ColorNavigator 7',
                                      'CFBundleShortVersionString': '7.2.0',
                                      'CFBundleVersion': '0',
                                      'minosversion': '10.14',
                                      'path': '/Applications/ColorNavigator '
                                              '7.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.10',
                        'name': 'ColorNavigator7',
                        'unattended_install': False,
                        'uninstall_method': 'uninstall_script',
                        'uninstall_script': '#!/bin/sh\n'
                                            '#Per the "Installation Guide"\n'
                                            '#https://www.eizoglobal.com/support/db/files/manuals/03V27670C1/UM-03V27670C1-EN.pdf\n'
                                            'rm -rf '
                                            '"/Applications/ColorNavigator '
                                            '7.app"\n'
                                            '\t\t\t\n'
                                            'pkgutil --forget '
                                            'com.eizo.pkg.ColorNavigator7',
                        'uninstallable': True}}}
Versioner
{'Input': {'input_plist_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root/Applications/ColorNavigator '
                               '7.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString',
           'skip_single_root_dir': False}}
Versioner: Found version 7.2.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload/root/Applications/ColorNavigator 7.app/Contents/Info.plist
{'Output': {'version': '7.2.0'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '7.2.0'},
           'pkginfo': {'RestartAction': 'RequireLogout',
                       'catalogs': ['development-eizo-ColorNavigator7'],
                       'category': 'Utility',
                       'description': 'Complete color management software '
                                      'solution for reliable calibration and '
                                      'quality control management of ColorEdge '
                                      'monitors.',
                       'developer': 'EIZO',
                       'display_name': 'ColorNavigator 7',
                       'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7',
                                     'CFBundleName': 'ColorNavigator 7',
                                     'CFBundleShortVersionString': '7.2.0',
                                     'CFBundleVersion': '0',
                                     'minosversion': '10.14',
                                     'path': '/Applications/ColorNavigator '
                                             '7.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.10',
                       'name': 'ColorNavigator7',
                       'unattended_install': False,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/sh\n'
                                           '#Per the "Installation Guide"\n'
                                           '#https://www.eizoglobal.com/support/db/files/manuals/03V27670C1/UM-03V27670C1-EN.pdf\n'
                                           'rm -rf '
                                           '"/Applications/ColorNavigator '
                                           '7.app"\n'
                                           '\t\t\t\n'
                                           'pkgutil --forget '
                                           'com.eizo.pkg.ColorNavigator7',
                       'uninstallable': True}}}
MunkiPkginfoMerger: Merged {'version': '7.2.0'} into pkginfo
{'Output': {'pkginfo': {'RestartAction': 'RequireLogout',
                        'catalogs': ['development-eizo-ColorNavigator7'],
                        'category': 'Utility',
                        'description': 'Complete color management software '
                                       'solution for reliable calibration and '
                                       'quality control management of '
                                       'ColorEdge monitors.',
                        'developer': 'EIZO',
                        'display_name': 'ColorNavigator 7',
                        'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7',
                                      'CFBundleName': 'ColorNavigator 7',
                                      'CFBundleShortVersionString': '7.2.0',
                                      'CFBundleVersion': '0',
                                      'minosversion': '10.14',
                                      'path': '/Applications/ColorNavigator '
                                              '7.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.10',
                        'name': 'ColorNavigator7',
                        'unattended_install': False,
                        'uninstall_method': 'uninstall_script',
                        'uninstall_script': '#!/bin/sh\n'
                                            '#Per the "Installation Guide"\n'
                                            '#https://www.eizoglobal.com/support/db/files/manuals/03V27670C1/UM-03V27670C1-EN.pdf\n'
                                            'rm -rf '
                                            '"/Applications/ColorNavigator '
                                            '7.app"\n'
                                            '\t\t\t\n'
                                            'pkgutil --forget '
                                            'com.eizo.pkg.ColorNavigator7',
                        'uninstallable': True,
                        'version': '7.2.0'}}}
PathDeleter
{'Input': {'path_list': ['/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack',
                         '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload']}}
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/unpack
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/payload
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/repack/ColorNavigator7-7.2.0.pkg',
           'pkginfo': {'RestartAction': 'RequireLogout',
                       'catalogs': ['development-eizo-ColorNavigator7'],
                       'category': 'Utility',
                       'description': 'Complete color management software '
                                      'solution for reliable calibration and '
                                      'quality control management of ColorEdge '
                                      'monitors.',
                       'developer': 'EIZO',
                       'display_name': 'ColorNavigator 7',
                       'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7',
                                     'CFBundleName': 'ColorNavigator 7',
                                     'CFBundleShortVersionString': '7.2.0',
                                     'CFBundleVersion': '0',
                                     'minosversion': '10.14',
                                     'path': '/Applications/ColorNavigator '
                                             '7.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.10',
                       'name': 'ColorNavigator7',
                       'unattended_install': False,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/sh\n'
                                           '#Per the "Installation Guide"\n'
                                           '#https://www.eizoglobal.com/support/db/files/manuals/03V27670C1/UM-03V27670C1-EN.pdf\n'
                                           'rm -rf '
                                           '"/Applications/ColorNavigator '
                                           '7.app"\n'
                                           '\t\t\t\n'
                                           'pkgutil --forget '
                                           'com.eizo.pkg.ColorNavigator7',
                       'uninstallable': True,
                       'version': '7.2.0'},
           'repo_subdirectory': 'apps/eizo'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/eizo/ColorNavigator7-7.2.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/eizo/ColorNavigator7-7.2.0.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'development-eizo-ColorNavigator7',
                                                       'icon_repo_path': '',
                                                       'name': 'ColorNavigator7',
                                                       'pkg_repo_path': 'apps/eizo/ColorNavigator7-7.2.0.pkg',
                                                       'pkginfo_path': 'apps/eizo/ColorNavigator7-7.2.0.plist',
                                                       'version': '7.2.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'RestartAction': 'RequireLogout',
                           '_metadata': {'created_by': 'paul.cossey',
                                         'creation_date': datetime.datetime(2024, 4, 15, 12, 23, 5),
                                         'munki_version': '6.3.2.4588',
                                         'os_version': '14.4.1'},
                           'autoremove': False,
                           'catalogs': ['development-eizo-ColorNavigator7'],
                           'category': 'Utility',
                           'description': 'Complete color management software '
                                          'solution for reliable calibration '
                                          'and quality control management of '
                                          'ColorEdge monitors.',
                           'developer': 'EIZO',
                           'display_name': 'ColorNavigator 7',
                           'installed_size': 485618,
                           'installer_item_hash': 'e720c16816abe65ef2e037d4538429b1238c4eca99b5d4440da5e9d97ac05693',
                           'installer_item_location': 'apps/eizo/ColorNavigator7-7.2.0.pkg',
                           'installer_item_size': 282786,
                           'installs': [{'CFBundleIdentifier': 'com.eizo.ColorNavigator7',
                                         'CFBundleName': 'ColorNavigator 7',
                                         'CFBundleShortVersionString': '7.2.0',
                                         'CFBundleVersion': '0',
                                         'minosversion': '10.14',
                                         'path': '/Applications/ColorNavigator '
                                                 '7.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.10',
                           'name': 'ColorNavigator7',
                           'receipts': [{'installed_size': 485618,
                                         'packageid': 'com.eizo.pkg.ColorNavigator7',
                                         'version': '7.2.0'}],
                           'unattended_install': False,
                           'uninstall_method': 'uninstall_script',
                           'uninstall_script': '#!/bin/sh\n'
                                               '#Per the "Installation Guide"\n'
                                               '#https://www.eizoglobal.com/support/db/files/manuals/03V27670C1/UM-03V27670C1-EN.pdf\n'
                                               'rm -rf '
                                               '"/Applications/ColorNavigator '
                                               '7.app"\n'
                                               '\t\t\t\n'
                                               'pkgutil --forget '
                                               'com.eizo.pkg.ColorNavigator7',
                           'uninstallable': True,
                           'version': '7.2.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/eizo/ColorNavigator7-7.2.0.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/eizo/ColorNavigator7-7.2.0.plist'}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.ColorNavigator7/receipts/ColorNavigator7.munki-receipt-20240415-132305.plist

The following new items were imported into Munki:
    Name             Version  Catalogs                          Pkginfo Path                           Pkg Repo Path                        Icon Repo Path  
    ----             -------  --------                          ------------                           -------------                        --------------  
    ColorNavigator7  7.2.0    development-eizo-ColorNavigator7  apps/eizo/ColorNavigator7-7.2.0.plist  apps/eizo/ColorNavigator7-7.2.0.pkg 
```