### PR TITLE
Update CaptureOne.download.recipe

### DIFF
--- a/PhaseOne/CaptureOne.download.recipe
+++ b/PhaseOne/CaptureOne.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>"latestCOVersions":.+?(https:\/\/downloads\.captureone\.pro\/[\dabcdef]+\/CaptureOne\.Mac[\d\.]+\.dmg)</string>
+				<string>\"latestCOVersions\":.+?(https://downloads\.captureone\.pro/d/mac/[A-Za-z0-9]+/CaptureOne\.Mac\.([0-9]+(\.[0-9]+)+)\.dmg)</string>
 				<key>url</key>
 				<string>https://www.captureone.com/en/account/download-trial</string>
 			</dict>


### PR DESCRIPTION
Hi, @foigus 

This PR updates the Regex so that it grabs the latest version and not an older version as it currently does. 

Output from a successful -vv run 
```
autopkg run -vv CaptureOnePerpetual.munki.recipe
Looking for com.github.foigus.download.CaptureOne...
Did not find com.github.foigus.download.CaptureOne in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.foigus.download.CaptureOne...
Found com.github.foigus.download.CaptureOne in recipe map
**load_recipe time: 0.008184166974388063
Processing CaptureOnePerpetual.munki.recipe...
WARNING: CaptureOnePerpetual.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '\\"latestCOVersions\\":.+?(https://downloads\\.captureone\\.pro/d/mac/[A-Za-z0-9]+/CaptureOne\\.Mac\\.([0-9]+(\\.[0-9]+)+)\\.dmg)',
           'url': 'https://www.captureone.com/en/account/download-trial'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://downloads.captureone.pro/d/mac/d59fe79f9b604e261bc2381e8630c68a73824654/CaptureOne.Mac.16.4.3.15.dmg
{'Output': {'match': 'https://downloads.captureone.pro/d/mac/d59fe79f9b604e261bc2381e8630c68a73824654/CaptureOne.Mac.16.4.3.15.dmg'}}
URLDownloader
{'Input': {'filename': 'CaptureOne.dmg',
           'url': 'https://downloads.captureone.pro/d/mac/d59fe79f9b604e261bc2381e8630c68a73824654/CaptureOne.Mac.16.4.3.15.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 14 Jun 2024 14:00:24 GMT
URLDownloader: Storing new ETag header: "399eca2f59f7ffba5778b1cdc177933a-210"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg
{'Output': {'download_changed': True,
            'etag': '"399eca2f59f7ffba5778b1cdc177933a-210"',
            'last_modified': 'Fri, 14 Jun 2024 14:00:24 GMT',
            'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg/Capture '
                         'One.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.captureone.captureone16" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5WTDB5F65L")'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.RfBfeM/Capture One.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.RfBfeM/Capture One.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.RfBfeM/Capture One.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
StopProcessingIf
{'Input': {'predicate': 'download_changed == FALSE AND STOP_ON_NO_NEW_DOWNLOAD '
                        '== TRUE'}}
StopProcessingIf: (download_changed == FALSE AND STOP_ON_NO_NEW_DOWNLOAD == TRUE) is False
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': '"latestCOVersions":.+?https:\\/\\/downloads\\.captureone\\.pro\\/[\\dabcdef]+\\/CaptureOne\\.Mac\\.([\\d]+\\.[\\d]+)\\.[\\d\\.]+\\.dmg',
           'result_output_var_name': 'perpetual_version',
           'url': 'https://www.captureone.com/en/account/download-trial'}}
URLTextSearcher: Found matching text (perpetual_version): 16.3
{'Output': {'perpetual_version': '16.3'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
com.github.jazzace.processors/TextSearcher
{'Input': {'re_pattern': '[^|]+',
           'result_output_var_name': 'calculated_catalog',
           'text_in': '|development-phaseone-CaptureOne16.3'}}
TextSearcher: Found matching text (calculated_catalog): development-phaseone-CaptureOne16.3
{'Output': {'calculated_catalog': 'development-phaseone-CaptureOne16.3'}}
com.github.jazzace.processors/TextSearcher
{'Input': {'re_pattern': '[^|]+',
           'result_output_var_name': 'calculated_display_name',
           'text_in': '|Capture One 16.3'}}
TextSearcher: Found matching text (calculated_display_name): Capture One 16.3
{'Output': {'calculated_display_name': 'Capture One 16.3'}}
com.github.jazzace.processors/TextSearcher
{'Input': {'re_pattern': '[^|]+',
           'result_output_var_name': 'calculated_name',
           'text_in': '|CaptureOne16.3'}}
TextSearcher: Found matching text (calculated_name): CaptureOne16.3
{'Output': {'calculated_name': 'CaptureOne16.3'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'catalogs': ['development-phaseone-CaptureOne16.3'],
                                  'display_name': 'Capture One 16.3',
                                  'name': 'CaptureOne16.3'},
           'pkginfo': {'category': 'Productivity',
                       'description': 'The professional choice in imaging '
                                      'software.',
                       'developer': 'Phase One',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'catalogs': ['development-phaseone-CaptureOne16.3'], 'display_name': 'Capture One 16.3', 'name': 'CaptureOne16.3'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['development-phaseone-CaptureOne16.3'],
                        'category': 'Productivity',
                        'description': 'The professional choice in imaging '
                                       'software.',
                        'developer': 'Phase One',
                        'display_name': 'Capture One 16.3',
                        'name': 'CaptureOne16.3',
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'force_munkiimport': 'totally',
           'pkg_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg',
           'pkginfo': {'catalogs': ['development-phaseone-CaptureOne16.3'],
                       'category': 'Productivity',
                       'description': 'The professional choice in imaging '
                                      'software.',
                       'developer': 'Phase One',
                       'display_name': 'Capture One 16.3',
                       'name': 'CaptureOne16.3',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/phaseone'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/phaseone/CaptureOne16.3-16.4.3.15.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/phaseone/CaptureOne-16.4.3.15.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'development-phaseone-CaptureOne16.3',
                                                       'icon_repo_path': '',
                                                       'name': 'CaptureOne16.3',
                                                       'pkg_repo_path': 'apps/phaseone/CaptureOne-16.4.3.15.dmg',
                                                       'pkginfo_path': 'apps/phaseone/CaptureOne16.3-16.4.3.15.plist',
                                                       'version': '16.4.3.15'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul.cossey',
                                         'creation_date': datetime.datetime(2024, 7, 3, 20, 40, 53),
                                         'munki_version': '6.3.2.4588',
                                         'os_version': '14.5'},
                           'autoremove': False,
                           'catalogs': ['development-phaseone-CaptureOne16.3'],
                           'category': 'Productivity',
                           'description': 'The professional choice in imaging '
                                          'software.',
                           'developer': 'Phase One',
                           'display_name': 'Capture One 16.3',
                           'installer_item_hash': '1ec36bad01b80d543e251fdf0b9a5449c27ccce3e4cd06688814e40541b43aa2',
                           'installer_item_location': 'apps/phaseone/CaptureOne-16.4.3.15.dmg',
                           'installer_item_size': 1072802,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.captureone.captureone16',
                                         'CFBundleName': 'Capture One',
                                         'CFBundleShortVersionString': '16.4.3.15',
                                         'CFBundleVersion': '16.4.3.15',
                                         'minosversion': '12.0',
                                         'path': '/Applications/Capture '
                                                 'One.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Capture '
                                                             'One.app'}],
                           'minimum_os_version': '12.0',
                           'name': 'CaptureOne16.3',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '16.4.3.15'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/phaseone/CaptureOne-16.4.3.15.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/phaseone/CaptureOne16.3-16.4.3.15.plist'}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/receipts/CaptureOnePerpetual.munki-receipt-20240703-214053.plist

The following new items were downloaded:
    Download Path                                                                                         
    -------------                                                                                         
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.CaptureOne/downloads/CaptureOne.dmg  

The following new items were imported into Munki:
    Name            Version    Catalogs                             Pkginfo Path                                  Pkg Repo Path                           Icon Repo Path  
    ----            -------    --------                             ------------                                  -------------                           --------------  
    CaptureOne16.3  16.4.3.15  development-phaseone-CaptureOne16.3  apps/phaseone/CaptureOne16.3-16.4.3.15.plist  apps/phaseone/CaptureOne-16.4.3.15.dmg
```