### PR TITLE
Add GUI-less option to MaxonApp.pkg

### DIFF
--- a/Maxon/MaxonApp.pkg.recipe
+++ b/Maxon/MaxonApp.pkg.recipe
@@ -3,13 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Maxon App and packages it for installation.</string>
+	<string>Downloads the latest version of Maxon App and packages it for installation.
+If you wish the resulting pkg to skip installation of the GUI, set INSTALL_OPTIONS to:
+--skipMaxonAppGui 1
+This recipe requires version 2024.1.0 or newer.</string>
 	<key>Identifier</key>
 	<string>com.github.foigus.pkg.MaxonApp</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>MaxonApp</string>
+		<key>INSTALL_OPTIONS</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -52,7 +57,7 @@ install_dir=`dirname $0`
 
 # Install Maxon App Installer using the script from the resources directory
 # Maxon documentation here: https://support.maxon.net/hc/en-us/articles/4687177301788-Running-Scripted-Installers
-"${install_dir}/Maxon App Installer.app/Contents/MacOS/installbuilder.sh" --mode unattended --unattendedmodeui none</string>
+"${install_dir}/Maxon App Installer.app/Contents/MacOS/installbuilder.sh" --mode unattended --unattendedmodeui none %INSTALL_OPTIONS%</string>
 				<key>file_mode</key>
 				<string>0755</string>
 				<key>file_path</key>


### PR DESCRIPTION
installbuilder.sh allows an option to skip installation of the Maxon App GUI. This PR allows the user to add that option to their pkg as documented in the Description. It also clarifies that the postinstall script only works for the 2024.1.0 version and later.