### PR TITLE
Migrate Microsoft Remote Desktop to new Windows App

### DIFF
--- a/Microsoft/MicrosoftRemoteDesktop.munki.recipe
+++ b/Microsoft/MicrosoftRemoteDesktop.munki.recipe
@@ -3,33 +3,33 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Microsoft Remote Desktop installer pkg and imports it into Munki.</string>
+	<string>Downloads the latest Windows App installer pkg and imports it into Munki.</string>
 	<key>Identifier</key>
-	<string>com.github.foigus.munki.microsoftremotedesktop</string>
+	<string>com.github.foigus.munki.microsoftwindowsapp</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/microsoft</string>
 		<key>NAME</key>
-		<string>MicrosoftRemoteDesktop</string>
+		<string>WindowsApp</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>
 			<array>
-				<string>Microsoft Remote Desktop</string>
+				<string>Windows App</string>
 			</array>
 			<key>catalogs</key>
 			<array>
-				<string>development-microsoft-MicrosoftRemoteDesktop</string>
+				<string>development-microsoft-MicrosoftWindowsApp</string>
 			</array>
 			<key>category</key>
 			<string>Utility</string>
 			<key>description</key>
-			<string>Use the new Microsoft Remote Desktop app to connect to a remote PC or virtual apps and desktops made available by your administrator. The app helps you be productive no matter where you are.</string>
+			<string>Use the new Windows App to connect to a remote PC or virtual apps and desktops made available by your administrator. The app helps you be productive no matter where you are.</string>
 			<key>developer</key>
 			<string>Microsoft</string>
 			<key>display_name</key>
-			<string>Microsoft Remote Desktop</string>
+			<string>Windows App</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -41,7 +41,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.rtrouton.download.microsoftremotedesktop</string>
+	<string>com.github.rtrouton.download.microsoftwindowsapp</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -77,7 +77,7 @@
 				<string>%RECIPE_CACHE_DIR%</string>
 				<key>installs_item_paths</key>
 				<array>
-					<string>/Applications/Microsoft Remote Desktop.app</string>
+					<string>/Applications/Windows App.app</string>
 				</array>
 				<key>version_comparison_key</key>
 				<string>CFBundleShortVersionString</string>
@@ -93,7 +93,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/Microsoft Remote Desktop.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/Windows App.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Issue for context: https://github.com/autopkg/foigus-recipes/issues/152

Migrated recipe to use rtrouton's new Windows App download recipe and updated the necessary parts of your munki recipe. Ran locally and successfully imported into our munki repo.