### PR TITLE
Update Kindle Create Recipes

### DIFF
--- a/Amazon/KindleCreate.download.recipe
+++ b/Amazon/KindleCreate.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://s3.amazonaws.com/kindlecreate/KindleCreateInstaller.pkg</string>
+		<string>https://d2bzeorukaqrvt.cloudfront.net/KindleCreateInstaller.pkg</string>
 		<key>NAME</key>
 		<string>KindleCreate</string>
 	</dict>

--- a/Amazon/KindleCreate.munki.recipe
+++ b/Amazon/KindleCreate.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Kindle Create package and imports it into Munki.</string>
+	<string>Downloads latest Kindle Create package and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.foigus.munki.kindlecreate</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/amazon</string>
 		<key>NAME</key>
@@ -37,11 +41,56 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.foigus.download.kindlecreate</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked</string>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked/KITCAppComponent.pkg/Payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Kindle Create.app</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -52,6 +101,18 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpacked</string>
+					<string>%RECIPE_CACHE_DIR%/Applications</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @foigus 

The current download recipe is downloading an older version (`1.60.0`) of Kindle Create

This PR 
- Updates the download URL
- Adds steps to create an Installs Array in the munki recipe with `derive_minimum_os_version` set. 
- PathDeleter to tidy up after

Output from a successful -v run 
```
autopkg run -v KindleCreate.munki.recipe
Looking for com.github.foigus.download.kindlecreate...
Did not find com.github.foigus.download.kindlecreate in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.foigus.download.kindlecreate...
Found com.github.foigus.download.kindlecreate in recipe map
**load_recipe time: 0.010193583002546802
Processing KindleCreate.munki.recipe...
WARNING: KindleCreate.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/downloads/KindleCreate.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "KindleCreate.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-02-07 06:30:07 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: AMZN Mobile LLC (94KV3E626L)
CodeSignatureVerifier:        Expires: 2027-06-28 22:57:06 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            49 68 39 4A BA 83 3B F0 CC 5E 98 3B E7 C1 72 AC 85 97 65 18 B9 4C 
CodeSignatureVerifier:            BA 34 62 BF E9 23 76 98 C5 DA
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/downloads/KindleCreate.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/unpacked
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/unpacked/KITCAppComponent.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Kindle Create.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.15.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.amazon.kc', 'CFBundleShortVersionString': '1.98', 'CFBundleVersion': '1.98', 'minosversion': '10.15.0', 'path': '/Applications/Kindle Create.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.15.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/amazon/KindleCreate-1.98.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/amazon/KindleCreate-1.98.0__1.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/unpacked
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/Applications
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.foigus.munki.kindlecreate/receipts/KindleCreate.munki-receipt-20250310-170930.plist

The following new items were imported into Munki:
    Name          Version  Catalogs                         Pkginfo Path                              Pkg Repo Path                           Icon Repo Path  
    ----          -------  --------                         ------------                              -------------                           --------------  
    KindleCreate  1.98.0   development-amazon-KindleCreate  apps/amazon/KindleCreate-1.98.0__1.plist  apps/amazon/KindleCreate-1.98.0__1.pkg
```