### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/EmSoftware/InDataCC2023.download.recipe
+++ b/EmSoftware/InDataCC2023.download.recipe
@@ -21,7 +21,7 @@
 				<key>re_pattern</key>
 				<string>href=\"(https:\/\/ftp\.emsoftware\.com\/installers\/indata\/InData_[\d]+_[\d]+_[\d]+_for_InDesign_2023_MacOS\.pkg)</string>
 				<key>url</key>
-				<string>http://emsoftware.com/products/emdata/</string>
+				<string>https://emsoftware.com/products/emdata/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Meteo/Meteorologist.download.recipe
+++ b/Meteo/Meteorologist.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Meteorologist</string>
 		<key>VERSION_URL</key>
-		<string>http://heat-meteo.sourceforge.net/VERSION2</string>
+		<string>https://heat-meteo.sourceforge.net/VERSION2</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.1</string>

--- a/X-Rite/i1Studio.download.recipe
+++ b/X-Rite/i1Studio.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>i1Studio</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://downloads.xrite.com/downloads/AutoUpdate/i1Studio/i1Studio_mac_appcast.xml</string>
+		<string>https://downloads.xrite.com/downloads/AutoUpdate/i1Studio/i1Studio_mac_appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._