### PR TITLE
Add code signature verification for Colour Contrast Analyser

### DIFF
--- a/ThePacielloGroup/ColourContrastAnalyser.download.recipe
+++ b/ThePacielloGroup/ColourContrastAnalyser.download.recipe
@@ -39,6 +39,17 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Colour Contrast Analyser.app</string>
+				<key>requirement</key>
+				<string>identifier "com.electron.cca" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34RS4UC3M6"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
CodeSignatureVerifier portion of verbose recipe run:

```
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.foigus.download.ColourContrastAnalyser/downloads/ColourContrastAnalyser.dmg/Colour '
                         'Contrast Analyser.app',
           'requirement': 'identifier "com.electron.cca" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"34RS4UC3M6"'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.foigus.download.ColourContrastAnalyser/downloads/ColourContrastAnalyser.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.lMBsRs/Colour Contrast Analyser.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.lMBsRs/Colour Contrast Analyser.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.lMBsRs/Colour Contrast Analyser.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```
