### PR TITLE
Rename 'pathname' to 'checksum_pathname' in multiple recipes

### DIFF
--- a/EIZO/ColorNavigator7.pkg.recipe
+++ b/EIZO/ColorNavigator7.pkg.recipe
@@ -47,7 +47,7 @@ autopkg repo-add jessepeterson-recipes</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>cd18484da57402375fe278dabd2654a9</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/ColorNavigator_7.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/Evolphin/EvolphinZoom.munki.recipe
+++ b/Evolphin/EvolphinZoom.munki.recipe
@@ -101,7 +101,7 @@ http://help.evolphin.com/docs/drag-and-drop-stopped-working-in-the-asset-browser
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>5c9aa8340bf5186d4baa4344f852cf77</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/payload_zoom/zoom/Resources/bin/uninstall</string>
 			</dict>
 			<key>Comment</key>
@@ -116,7 +116,7 @@ http://help.evolphin.com/docs/drag-and-drop-stopped-working-in-the-asset-browser
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>dcfaf53236397eab4ff0e9baf5e60d71</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/payload_zoom/zoom/Uninstall Zoom.app/Contents/Resources/Scripts/main.scpt</string>
 			</dict>
 			<key>Comment</key>

--- a/Evolphin/EvolphinZoom.pkg.recipe
+++ b/Evolphin/EvolphinZoom.pkg.recipe
@@ -57,7 +57,7 @@ autopkg run EvolphinZoom.pkg -p /path/to/EvolphinZoom.pkg</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>b829d3f425856c5a0f06d7ad4b537af6</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/zoom.pkg/Scripts/preinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -72,7 +72,7 @@ autopkg run EvolphinZoom.pkg -p /path/to/EvolphinZoom.pkg</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>1ee65da5a523b1f227a1bf36baae193f</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/zoom.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -87,7 +87,7 @@ autopkg run EvolphinZoom.pkg -p /path/to/EvolphinZoom.pkg</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>5c9aa8340bf5186d4baa4344f852cf77</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/payload_zoom/zoom/Resources/bin/uninstall</string>
 			</dict>
 			<key>Comment</key>
@@ -102,7 +102,7 @@ autopkg run EvolphinZoom.pkg -p /path/to/EvolphinZoom.pkg</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>dcfaf53236397eab4ff0e9baf5e60d71</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/payload_zoom/zoom/Uninstall Zoom.app/Contents/Resources/Scripts/main.scpt</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner11ExportCC2015.pkg.recipe
+++ b/GMCSoftware/InspireDesigner11ExportCC2015.pkg.recipe
@@ -60,7 +60,7 @@ autopkg run InspireDesigner11ExportCC2015.pkg -p /path/to/Adobe-InDesign-CC-2015
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f9ade25f8f8379e8ac7216366812f20b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%found_filename%/Scripts/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -161,7 +161,7 @@ TestInDesignFolder()
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f9ade25f8f8379e8ac7216366812f20b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/expand_pkg_recipe/Configuration_File.pkg/Scripts/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -262,7 +262,7 @@ TestInDesignFolder()
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>b300783770bc19a56699566e8ba2820c</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/expand_pkg_recipe/Scripts/InstallationTargetChooser.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner11ExportCC2017.pkg.recipe
+++ b/GMCSoftware/InspireDesigner11ExportCC2017.pkg.recipe
@@ -60,7 +60,7 @@ autopkg run InspireDesigner11ExportCC2017.pkg -p /path/to/Adobe-InDesign-CC-2017
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>09b113d35dda57c47c09ce91fdea057c</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%found_filename%/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner12ExportCC2018.pkg.recipe
+++ b/GMCSoftware/InspireDesigner12ExportCC2018.pkg.recipe
@@ -60,7 +60,7 @@ autopkg run InspireDesigner12ExportCC2018.pkg -p /path/to/Adobe-InDesign-CC-2018
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>533d15d864c8e0ac0be5ff574376c73a</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%found_filename%/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner14ExportCC2020.pkg.recipe
+++ b/GMCSoftware/InspireDesigner14ExportCC2020.pkg.recipe
@@ -60,7 +60,7 @@ autopkg run InspireDesigner14ExportCC2020.pkg -p /path/to/Adobe-InDesign-2020-Pl
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>533d15d864c8e0ac0be5ff574376c73a</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%found_filename%/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner15ExportCC2022.pkg.recipe
+++ b/GMCSoftware/InspireDesigner15ExportCC2022.pkg.recipe
@@ -60,7 +60,7 @@ autopkg run InspireDesigner15ExportCC2022.pkg -p /path/to/InstallerPackage-Adobe
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>c154c8a915963f28649c1c39870750e0</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%found_filename%/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner16ExportCC2023.pkg.recipe
+++ b/GMCSoftware/InspireDesigner16ExportCC2023.pkg.recipe
@@ -60,7 +60,7 @@ autopkg run InspireDesigner16ExportCC2023.pkg -p /path/to/InstallerPackage-Adobe
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>c154c8a915963f28649c1c39870750e0</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%found_filename%/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesigner16ExportCC2024.pkg.recipe
+++ b/GMCSoftware/InspireDesigner16ExportCC2024.pkg.recipe
@@ -60,7 +60,7 @@ autopkg run InspireDesigner16ExportCC2024.pkg -p /path/to/InstallerPackage-Adobe
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>c154c8a915963f28649c1c39870750e0</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%found_filename%/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesignerExportCC2014.pkg.recipe
+++ b/GMCSoftware/InspireDesignerExportCC2014.pkg.recipe
@@ -67,7 +67,7 @@ autopkg run InspireDesignerExportCC2014.pkg -p /path/to/Adobe-InDesign-CC-Plugin
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f638ab030aa7c4f58d607b0f905e3a48</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/copied_pkg_recipe/Inspire Designer Export CC 2014.mpkg/Contents/Resources/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -168,7 +168,7 @@ TestInDesignFolder()
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f638ab030aa7c4f58d607b0f905e3a48</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/copied_pkg_recipe/Inspire Designer Export CC 2014.mpkg/Contents/Resources/%fancy_package_name%.pkg/Contents/Resources/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -269,7 +269,7 @@ TestInDesignFolder()
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f638ab030aa7c4f58d607b0f905e3a48</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/copied_pkg_recipe/Inspire Designer Export CC 2014.mpkg/Contents/Resources/%fancy_package_name% Configuration File.pkg/Contents/Resources/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/GMCSoftware/InspireDesignerExportCC2015.pkg.recipe
+++ b/GMCSoftware/InspireDesignerExportCC2015.pkg.recipe
@@ -67,7 +67,7 @@ autopkg run InspireDesignerExportCC2015.pkg -p /path/to/Adobe-InDesign-CC-2015-M
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f638ab030aa7c4f58d607b0f905e3a48</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/copied_pkg_recipe/Inspire Designer Export CC 2015.mpkg/Contents/Resources/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -168,7 +168,7 @@ TestInDesignFolder()
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f638ab030aa7c4f58d607b0f905e3a48</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/copied_pkg_recipe/Inspire Designer Export CC 2015.mpkg/Contents/Resources/%fancy_package_name%.pkg/Contents/Resources/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -269,7 +269,7 @@ TestInDesignFolder()
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f638ab030aa7c4f58d607b0f905e3a48</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/copied_pkg_recipe/Inspire Designer Export CC 2015.mpkg/Contents/Resources/%fancy_package_name% Configuration File.pkg/Contents/Resources/plugin-utils.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/Olympus/DSSPlayer.pkg.recipe
+++ b/Olympus/DSSPlayer.pkg.recipe
@@ -53,7 +53,7 @@ autopkg repo-add hjuutilainen-recipes
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>10a9bd1a5d7c14f71c666c1bc9bf2989</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/dssplayerv7.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -166,7 +166,7 @@ exit 0</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>c7e136d24d46f7ac207b610bc422e5e7</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/dsslanguagepacksv.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/AssetsInDesignCC2018Plugin.munki.recipe
+++ b/WoodWing/AssetsInDesignCC2018Plugin.munki.recipe
@@ -93,7 +93,7 @@ autopkg run AssetsInDesignCC2018Plugin.munki -p /path/WoodWing\ Assets\ for\ InD
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>0d23f2cd06f7fe62eeeedfc3b5270439</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Assets for InDesign.app/Contents/MacOS/Uninstall WoodWing Assets for InDesign</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/AssetsInDesignCC2020Plugin.munki.recipe
+++ b/WoodWing/AssetsInDesignCC2020Plugin.munki.recipe
@@ -93,7 +93,7 @@ autopkg run AssetsInDesignCC2020Plugin.munki -p /path/WoodWing\ Assets\ for\ InD
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>5b090ab28bc7316d447625b19b1d4293</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Assets for InDesign.app/Contents/MacOS/Uninstall WoodWing Assets for InDesign</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/AssetsInDesignCC2022Plugin.munki.recipe
+++ b/WoodWing/AssetsInDesignCC2022Plugin.munki.recipe
@@ -93,7 +93,7 @@ autopkg run AssetsInDesignCC2022Plugin.munki -p /path/WoodWing\ Assets\ for\ InD
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>5b090ab28bc7316d447625b19b1d4293</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Assets for InDesign.app/Contents/MacOS/Uninstall WoodWing Assets for InDesign</string>
 			</dict>
 			<key>Comment</key>
@@ -108,7 +108,7 @@ autopkg run AssetsInDesignCC2022Plugin.munki -p /path/WoodWing\ Assets\ for\ InD
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>c3c810b0a6dd92a271aa01f02812ca74</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/ASSETSID2022.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/AssetsInDesignCC2023Plugin.munki.recipe
+++ b/WoodWing/AssetsInDesignCC2023Plugin.munki.recipe
@@ -93,7 +93,7 @@ autopkg run AssetsInDesignCC2023Plugin.munki -p /path/WoodWing\ Assets\ for\ InD
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>5b090ab28bc7316d447625b19b1d4293</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Assets for InDesign.app/Contents/MacOS/Uninstall WoodWing Assets for InDesign</string>
 			</dict>
 			<key>Comment</key>
@@ -108,7 +108,7 @@ autopkg run AssetsInDesignCC2023Plugin.munki -p /path/WoodWing\ Assets\ for\ InD
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>c3c810b0a6dd92a271aa01f02812ca74</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/ASSETSID2023.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/ElvisInDesignCC2015Plugin.munki.recipe
+++ b/WoodWing/ElvisInDesignCC2015Plugin.munki.recipe
@@ -93,7 +93,7 @@ autopkg run ElvisInDesignCC2015Plugin.munki -p /path/to/Elvis\ InDesign.pkg</str
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>3a78c255a552075bb97240abd60ebba5</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Elvis InDesign Plug-ins.app/Contents/MacOS/Uninstall Elvis InDesign Plug-ins</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/ElvisInDesignCC2018Plugin.munki.recipe
+++ b/WoodWing/ElvisInDesignCC2018Plugin.munki.recipe
@@ -93,7 +93,7 @@ autopkg run ElvisInDesignCC2018Plugin.munki -p /path/to/Elvis\ InDesign.pkg</str
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>3a78c255a552075bb97240abd60ebba5</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Elvis InDesign Plug-ins.app/Contents/MacOS/Uninstall Elvis InDesign Plug-ins</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/ElvisInDesignCC2019Plugin.munki.recipe
+++ b/WoodWing/ElvisInDesignCC2019Plugin.munki.recipe
@@ -93,7 +93,7 @@ autopkg run ElvisInDesignCC2019Plugin.munki -p /path/to/Elvis\ InDesign.pkg</str
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>3a78c255a552075bb97240abd60ebba5</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Elvis InDesign Plug-ins.app/Contents/MacOS/Uninstall Elvis InDesign Plug-ins</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionCC2014.pkg.recipe
+++ b/WoodWing/WoodwingSmartConnectionCC2014.pkg.recipe
@@ -53,7 +53,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -68,7 +68,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -83,7 +83,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -98,7 +98,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>6a76506595c1492c08b21a904ea67759</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -113,7 +113,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -128,7 +128,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -143,7 +143,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -158,7 +158,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>6a76506595c1492c08b21a904ea67759</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -173,7 +173,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -188,7 +188,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -203,7 +203,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -218,7 +218,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>6a76506595c1492c08b21a904ea67759</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -233,7 +233,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -248,7 +248,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -263,7 +263,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -278,7 +278,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>6a76506595c1492c08b21a904ea67759</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionCC2015.pkg.recipe
+++ b/WoodWing/WoodwingSmartConnectionCC2015.pkg.recipe
@@ -53,7 +53,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -68,7 +68,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -83,7 +83,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -98,7 +98,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>675934d17b0b2968d505cc79330f1973</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesign.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -113,7 +113,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -128,7 +128,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -143,7 +143,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -158,7 +158,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>675934d17b0b2968d505cc79330f1973</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/indesigndm.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -173,7 +173,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -188,7 +188,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -203,7 +203,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -218,7 +218,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>675934d17b0b2968d505cc79330f1973</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopy.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -233,7 +233,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>4506d51028b560c6bb7dfef0c26018fe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/addRight.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -248,7 +248,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>
@@ -263,7 +263,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>05ba5f4f28758ed795c3f6a412301d2d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/postinstall.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -278,7 +278,7 @@ autopkg run WoodwingSmartConnectionCC2015.pkg -p /path/to/Smart_Connection_for_A
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>675934d17b0b2968d505cc79330f1973</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/incopyoverset.pkg/Scripts/total.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInCopyCC2014.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInCopyCC2014.munki.recipe
@@ -141,7 +141,7 @@ Requirement for ExtensionManagerCC is for Sticky Notes plugin install</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>84a03bad8a17deedde3e01a2661c098b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum</string>
 			</dict>
 			<key>Comment</key>
@@ -171,7 +171,7 @@ Requirement for ExtensionManagerCC is for Sticky Notes plugin install</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>84a03bad8a17deedde3e01a2661c098b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInCopyCC2015.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInCopyCC2015.munki.recipe
@@ -139,7 +139,7 @@ autopkg run WoodwingSmartConnectionInCopyCC2015.munki -p /path/to/Smart_Connecti
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>e6a61acf275e0e5c4b77480be1517b57</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum</string>
 			</dict>
 			<key>Comment</key>
@@ -169,7 +169,7 @@ autopkg run WoodwingSmartConnectionInCopyCC2015.munki -p /path/to/Smart_Connecti
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>e6a61acf275e0e5c4b77480be1517b57</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInCopyCC2018.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInCopyCC2018.munki.recipe
@@ -113,7 +113,7 @@ autopkg run WoodwingSmartConnectionInCopyCC2018.munki -p /path/to/Smart_Connecti
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>74ac73fa29d6cd08c50efa28cecc29ea</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Smart Connection for Adobe CC 2018.app/Contents/MacOS/Uninstall Smart Connection for Adobe CC 2018</string>
 			</dict>
 			<key>Comment</key>
@@ -128,7 +128,7 @@ autopkg run WoodwingSmartConnectionInCopyCC2018.munki -p /path/to/Smart_Connecti
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>74ac73fa29d6cd08c50efa28cecc29ea</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Smart Connection for Adobe CC 2018.app/Contents/Resources/Uninstall Smart Connection for Adobe CC 2018.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInDesignCC2014.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInDesignCC2014.munki.recipe
@@ -125,7 +125,7 @@ Requirement of ExtensionManagerCC is for Sticky Notes plugin install.</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>84a03bad8a17deedde3e01a2661c098b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum</string>
 			</dict>
 			<key>Comment</key>
@@ -155,7 +155,7 @@ Requirement of ExtensionManagerCC is for Sticky Notes plugin install.</string>
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>84a03bad8a17deedde3e01a2661c098b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInDesignCC2015.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInDesignCC2015.munki.recipe
@@ -123,7 +123,7 @@ autopkg run WoodwingSmartConnectionInDesignCC2015.munki -p /path/to/Smart_Connec
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>e6a61acf275e0e5c4b77480be1517b57</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum</string>
 			</dict>
 			<key>Comment</key>
@@ -153,7 +153,7 @@ autopkg run WoodwingSmartConnectionInDesignCC2015.munki -p /path/to/Smart_Connec
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>e6a61acf275e0e5c4b77480be1517b57</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInDesignCC2018.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInDesignCC2018.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingSmartConnectionInDesignCC2018.munki -p /path/to/Smart_Connec
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>74ac73fa29d6cd08c50efa28cecc29ea</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Smart Connection for Adobe CC 2018.app/Contents/MacOS/Uninstall Smart Connection for Adobe CC 2018</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingSmartConnectionInDesignCC2018.munki -p /path/to/Smart_Connec
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>74ac73fa29d6cd08c50efa28cecc29ea</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Smart Connection for Adobe CC 2018.app/Contents/Resources/Uninstall Smart Connection for Adobe CC 2018.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInDesignCC2019.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInDesignCC2019.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingSmartConnectionInDesignCC2019.munki -p /path/to/Smart_Connec
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>884691ad0f748ecc999d38bd338c4dbe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Smart Connection for Adobe CC2019.app/Contents/MacOS/Uninstall Smart Connection for Adobe CC2019</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingSmartConnectionInDesignCC2019.munki -p /path/to/Smart_Connec
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>884691ad0f748ecc999d38bd338c4dbe</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall Smart Connection for Adobe CC2019.app/Contents/Resources/Uninstall Smart Connection for Adobe CC2019.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInDesignDigitalMagazineCC2014.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInDesignDigitalMagazineCC2014.munki.recipe
@@ -122,7 +122,7 @@ autopkg run WoodwingSmartConnectionInDesignDigitalMagazineCC2014.munki -p /path/
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>84a03bad8a17deedde3e01a2661c098b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum</string>
 			</dict>
 			<key>Comment</key>
@@ -152,7 +152,7 @@ autopkg run WoodwingSmartConnectionInDesignDigitalMagazineCC2014.munki -p /path/
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>84a03bad8a17deedde3e01a2661c098b</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingSmartConnectionInDesignDigitalMagazineCC2015.munki.recipe
+++ b/WoodWing/WoodwingSmartConnectionInDesignDigitalMagazineCC2015.munki.recipe
@@ -123,7 +123,7 @@ autopkg run WoodwingSmartConnectionInDesignDigitalMagazineCC2015.munki -p /path/
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>e6a61acf275e0e5c4b77480be1517b57</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum</string>
 			</dict>
 			<key>Comment</key>
@@ -153,7 +153,7 @@ autopkg run WoodwingSmartConnectionInDesignDigitalMagazineCC2015.munki -p /path/
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>e6a61acf275e0e5c4b77480be1517b57</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/checksum.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInCopyCC2020.munki.recipe
+++ b/WoodWing/WoodwingStudioInCopyCC2020.munki.recipe
@@ -98,7 +98,7 @@ autopkg run WoodwingStudioInCopyCC2020.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>94044cb774d8f59525267e9be6d7c7ad</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2020.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2020</string>
 			</dict>
 			<key>Comment</key>
@@ -113,7 +113,7 @@ autopkg run WoodwingStudioInCopyCC2020.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>94044cb774d8f59525267e9be6d7c7ad</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2020.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2020.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInCopyCC2022.munki.recipe
+++ b/WoodWing/WoodwingStudioInCopyCC2022.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingStudioInCopyCC2022.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2022.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2022</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingStudioInCopyCC2022.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2022.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2022.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -127,7 +127,7 @@ autopkg run WoodwingStudioInCopyCC2022.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>cf92122a72b1a60b6a97a9843efc7a1d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/WWSTUDIOIC2022.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInCopyCC2023.munki.recipe
+++ b/WoodWing/WoodwingStudioInCopyCC2023.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingStudioInCopyCC2023.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2023.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2023</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingStudioInCopyCC2023.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2023.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2023.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -127,7 +127,7 @@ autopkg run WoodwingStudioInCopyCC2023.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f831aa3b94ed254fb7d03d7db048fd62</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/WWSTUDIOIC2023.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInCopyCC2024.munki.recipe
+++ b/WoodWing/WoodwingStudioInCopyCC2024.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingStudioInCopyCC2024.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2024.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2024</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingStudioInCopyCC2024.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2024.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2024.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -127,7 +127,7 @@ autopkg run WoodwingStudioInCopyCC2024.munki.recipe -p /path/to/WoodWing_Studio_
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>ab7bd00b87c4f8aa3bc17d18222e0576</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/WWSTUDIOIC2024.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInDesignCC2020.munki.recipe
+++ b/WoodWing/WoodwingStudioInDesignCC2020.munki.recipe
@@ -98,7 +98,7 @@ autopkg run WoodwingStudioInDesignCC2020.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>94044cb774d8f59525267e9be6d7c7ad</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2020.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2020</string>
 			</dict>
 			<key>Comment</key>
@@ -113,7 +113,7 @@ autopkg run WoodwingStudioInDesignCC2020.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>94044cb774d8f59525267e9be6d7c7ad</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2020.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2020.sh</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInDesignCC2022.munki.recipe
+++ b/WoodWing/WoodwingStudioInDesignCC2022.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingStudioInDesignCC2022.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2022.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2022</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingStudioInDesignCC2022.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2022.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2022.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -127,7 +127,7 @@ autopkg run WoodwingStudioInDesignCC2022.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>cf92122a72b1a60b6a97a9843efc7a1d</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/WWSTUDIOID2022.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInDesignCC2023.munki.recipe
+++ b/WoodWing/WoodwingStudioInDesignCC2023.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingStudioInDesignCC2023.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2023.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2023</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingStudioInDesignCC2023.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2023.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2023.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -127,7 +127,7 @@ autopkg run WoodwingStudioInDesignCC2023.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>f831aa3b94ed254fb7d03d7db048fd62</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/WWSTUDIOID2023.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>

--- a/WoodWing/WoodwingStudioInDesignCC2024.munki.recipe
+++ b/WoodWing/WoodwingStudioInDesignCC2024.munki.recipe
@@ -97,7 +97,7 @@ autopkg run WoodwingStudioInDesignCC2024.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2024.app/Contents/MacOS/Uninstall WoodWing Studio for InDesign and InCopy 2024</string>
 			</dict>
 			<key>Comment</key>
@@ -112,7 +112,7 @@ autopkg run WoodwingStudioInDesignCC2024.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>88f44c5308414445efa5c6b25860a237</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/payload.pkg/Scripts/Uninstall WoodWing Studio for InDesign and InCopy 2024.app/Contents/Resources/Uninstall WoodWing Studio for InDesign and InCopy 2024.sh</string>
 			</dict>
 			<key>Comment</key>
@@ -127,7 +127,7 @@ autopkg run WoodwingStudioInDesignCC2024.munki.recipe -p /path/to/WoodWing_Studi
 				<string>MD5</string>
 				<key>checksum</key>
 				<string>ab7bd00b87c4f8aa3bc17d18222e0576</string>
-				<key>pathname</key>
+				<key>checksum_pathname</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/WWSTUDIOID2024.pkg/Scripts/postinstall</string>
 			</dict>
 			<key>Comment</key>


### PR DESCRIPTION
Hi, @foigus 

This PR replaces all instances of the `pathname` key with `checksum_pathname` in various recipes, due to this PR autopkg/hjuutilainen-recipes#303 being merged to address autopkg/hjuutilainen-recipes#271

Please also make sure to update https://github.com/autopkg/hjuutilainen-recipes to get the latest version of `ChecksumVerifier`

Thanks!