### PR TITLE
Update download URL for RealVNC Viewer

### DIFF
--- a/RealVNC/RealVNCViewer.download.recipe
+++ b/RealVNC/RealVNCViewer.download.recipe
@@ -20,28 +20,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>(VNC-Viewer-([A-Za-z0-9]+(\.[A-Za-z0-9]+)+)-MacOSX-universal\.dmg)</string>
-				<key>request_headers</key>
-				<dict>
-					<key>user-agent</key>
-					<string>%USER_AGENT%</string>
-				</dict>
-				<key>result_output_var_name</key>
-				<string>dmg_name</string>
-				<key>url</key>
-				<string>https://www.realvnc.com/download/viewer/macosx/</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://downloads.realvnc.com/download/file/viewer.files/%dmg_name%</string>
+				<string>https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-Latest-MacOSX-universal.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Eliminates scraping URL text for a dmg name and now uses a static "latest" URL. Addresses #162