### PR TITLE
Add USER_AGENT to Tableau download recipes

### DIFF
--- a/Tableau/TableauPublic.download.recipe
+++ b/Tableau/TableauPublic.download.recipe
@@ -8,10 +8,12 @@
 	<string>com.github.foigus.download.tableau-public</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://public.tableau.com/s/download/public/mac</string>
 		<key>NAME</key>
 		<string>TableauPublic</string>
+		<key>DOWNLOAD_URL</key>
+		<string>https://public.tableau.com/s/download/public/mac</string>
+        <key>USER_AGENT</key>
+        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) Tableau Safari/538.1</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -24,6 +26,11 @@
 				<string>%NAME%.dmg</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
+				<key>request_headers</key>
+				<dict>
+					<key>user-agent</key>
+					<string>%USER_AGENT%</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Tableau/TableauReader.download.recipe
+++ b/Tableau/TableauReader.download.recipe
@@ -10,7 +10,7 @@
 	<dict>
 		<key>NAME</key>
 		<string>TableauReader</string>
-		<key>DOWNLOAD_URL</key>
+		<key>url</key>
 		<string>https://www.tableau.com/downloads/reader/mac</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) Tableau Safari/538.1</string>
@@ -24,8 +24,6 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
 				<key>request_headers</key>
 				<dict>
 					<key>user-agent</key>

--- a/Tableau/TableauReader.download.recipe
+++ b/Tableau/TableauReader.download.recipe
@@ -10,8 +10,10 @@
 	<dict>
 		<key>NAME</key>
 		<string>TableauReader</string>
-		<key>url</key>
+		<key>DOWNLOAD_URL</key>
 		<string>https://www.tableau.com/downloads/reader/mac</string>
+        <key>USER_AGENT</key>
+        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) Tableau Safari/538.1</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.1</string>
@@ -22,6 +24,13 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>request_headers</key>
+				<dict>
+					<key>user-agent</key>
+					<string>%USER_AGENT%</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Added USER_AGENT variable to fix the random 403 forbidden errors I was getting during checks. Light linting to make download recipes align better.